### PR TITLE
Return tools/list in a deterministic order

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -2,6 +2,7 @@ package envoy_mcp_openapi_processor
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -66,8 +67,8 @@ func (r *toolRegistry) Len() int {
 	return len(r.tools)
 }
 
-// Register adds a tool and its configuration to the registry.
-// Returns an error if the tool is nil or if tool name validation fails.
+// Register inserts the tool at its sorted position. A deterministic list order
+// is a 2026-07-28 SHOULD, and it also benefits legacy clients.
 func (r *toolRegistry) Register(tool *mcp.Tool, config *toolConfig) error {
 	if tool == nil {
 		return fmt.Errorf("tool cannot be nil")
@@ -78,10 +79,13 @@ func (r *toolRegistry) Register(tool *mcp.Tool, config *toolConfig) error {
 	if err := validateToolName(tool.Name); err != nil {
 		return err
 	}
-	if _, exists := r.configs[tool.Name]; exists {
+	position, registered := slices.BinarySearchFunc(r.tools, tool.Name, func(candidate *mcp.Tool, name string) int {
+		return strings.Compare(candidate.Name, name)
+	})
+	if registered {
 		return fmt.Errorf("tool '%s' already registered", tool.Name)
 	}
-	r.tools = append(r.tools, tool)
+	r.tools = slices.Insert(r.tools, position, tool)
 	r.configs[tool.Name] = config
 	return nil
 }
@@ -111,7 +115,7 @@ func (r *toolRegistry) GetConfig(name string) *toolConfig {
 	return r.configs[name]
 }
 
-// Tools returns the tools in the registry.
+// Tools returns the tools in the registry, sorted by name.
 // The returned slice should be treated as read-only. Callers must not modify
 // the slice or its contents
 func (r *toolRegistry) Tools() []*mcp.Tool {

--- a/registry_test.go
+++ b/registry_test.go
@@ -27,6 +27,14 @@ func mkToolRegistryFromConfig(t *testing.T, config *ToolRegistryConfig) *toolReg
 	return registry
 }
 
+func toolNames(registry *toolRegistry) []string {
+	names := make([]string, 0, registry.Len())
+	for _, tool := range registry.Tools() {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
 func TestToolRegistry_FilterByAllowlist_FiltersTools(t *testing.T) {
 	registry := mkDefaultToolRegistry(t)
 
@@ -75,7 +83,7 @@ func TestToolRegistry_String(t *testing.T) {
 
 	result := registry.String()
 
-	assert.Equal(t, "[listUsers => GET api.example.com/users, createUser => POST api.example.com/users]", result)
+	assert.Equal(t, "[createUser => POST api.example.com/users, listUsers => GET api.example.com/users]", result)
 }
 
 func TestToolRegistry_FilterByAllowlist_EmptyAllowlistReturnsError(t *testing.T) {
@@ -137,6 +145,31 @@ func TestToolRegistry_Register_RejectsInvalidToolNames(t *testing.T) {
 			assert.Equal(t, 0, registry.Len())
 		})
 	}
+}
+
+func TestToolRegistry_Register_KeepsToolsSortedByName(t *testing.T) {
+	registry := newToolRegistry()
+
+	for _, toolName := range []string{"t3", "t2", "t1"} {
+		require.NoError(t, registry.Register(
+			&mcp.Tool{Name: toolName},
+			&toolConfig{Endpoint: endpoint{Host: "api.example.com", Method: "get", PathTemplate: "/" + toolName}},
+		))
+	}
+
+	assert.Equal(t, []string{"t1", "t2", "t3"}, toolNames(registry))
+}
+
+func TestToolRegistry_Register_RejectsDuplicateToolNames(t *testing.T) {
+	registry := newToolRegistry()
+	tool := &mcp.Tool{Name: "t1"}
+	config := &toolConfig{Endpoint: endpoint{Host: "api.example.com", Method: "get", PathTemplate: "/users"}}
+	require.NoError(t, registry.Register(tool, config))
+
+	err := registry.Register(tool, config)
+
+	assert.EqualError(t, err, "tool 't1' already registered")
+	assert.Equal(t, 1, registry.Len())
 }
 
 func TestToolRegistry_Register_AllowsSpecCompliantToolNames(t *testing.T) {


### PR DESCRIPTION
The mcp 2026-07-28 revision says servers SHOULD return tools from tools/list
in a deterministic order (changelog Minor 3).

The registry is built by walking the OpenAPI spec's path and operation
maps, so Go's randomized map iteration gave a different tool order on
every process start. Sort by name once, after the registry is fully
loaded. Legacy clients benefit from the same stability.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>