### PR TITLE
Serve modern 2026-07-28 requests alongside the legacy handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ go get github.com/ing-bank/envoy-mcp-openapi-processor
 See [`examples/mcp-server`](examples/mcp-server) for a complete working example including Envoy proxy configured to use the
 `envoy-mcp-openapi-processor` server.
 
+## Supported MCP Protocol Versions
+
+The processor is a dual-era MCP server supporting `2025-06-18`, `2025-11-25` and `2026-07-28`. The two eras have
+disjoint entry points, so every request selects one unambiguously:
+
+- **Legacy era (`2025-06-18`, `2025-11-25`)**: the client starts with the `initialize` handshake and declares no
+  version on subsequent requests. Version negotiation never yields a modern version, so a client that asks for
+  one over the handshake is answered with a version it can actually use statefully.
+- **Modern era (`2026-07-28`)**: there is no handshake, and every request carries its protocol version in
+  `params._meta` (`io.modelcontextprotocol/protocolVersion`). Results carry `resultType` and the serverInfo
+  `_meta` entry, and an unknown method answers HTTP 404 rather than the legacy 200.
+
 ## OpenTelemetry
 
 To enable export of logs and traces to an OpenTelemetry collector, use one of the options below. If neither is used, the server runs with a no-op tracer provider and a no-op logger.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -176,6 +176,80 @@ case_malformed_json() {
   pass "$name"
 }
 
+# --- 2026-07-28 (modern era) probes ---
+#
+# Modern requests are stateless: there is no handshake, and every request
+# carries its protocol version in params._meta.
+
+MODERN_META='"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}'
+
+case_modern_tools_list() {
+  local name="modern tools/list -> shaped result"
+  post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/list\",\"params\":{$MODERN_META}}" || return 0
+  assert_jq "$name" '.id == 21 and .result.resultType == "complete" and (.result.tools | length > 0)' || return 0
+  assert_jq "$name" '.result._meta["io.modelcontextprotocol/serverInfo"] != null' || return 0
+  pass "$name"
+}
+
+# the only modern probe answered through the upstream (reroute) path.
+case_modern_tool_call() {
+  local name="modern tools/call getPetById -> shaped result"
+  post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":\"tools/call\",\"params\":{\"name\":\"getPetById\",\"arguments\":{\"petId\":1},$MODERN_META}}" \
+    -H 'api_key: e2e' || return 0
+  assert_jq "$name" '.id == 22 and .result.isError != true' || return 0
+  assert_jq "$name" '.result.resultType == "complete"' || return 0
+  assert_jq "$name" '.result._meta["io.modelcontextprotocol/serverInfo"] != null' || return 0
+  pass "$name"
+}
+
+case_modern_unsupported_version() {
+  local name="unsupported protocol version -> 400 with supported list"
+  post "$name" 400 '{"jsonrpc":"2.0","id":24,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}' || return 0
+  assert_jq "$name" '.error.code == -32022' || return 0
+  assert_jq "$name" '.error.data.supported | index("2026-07-28") != null' || return 0
+  assert_jq "$name" '.error.data.requested == "2099-01-01"' || return 0
+  pass "$name"
+}
+
+# only a declaration at or past the cutover announces modern intent. A
+# pre-cutover one is a legacy client restating its negotiated version, so it is
+# served as if _meta were absent.
+case_precutover_meta_version() {
+  local name="pre-cutover _meta version -> served as legacy"
+  post "$name" 200 '{"jsonrpc":"2.0","id":28,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}' || return 0
+  assert_jq "$name" '.id == 28 and (.result.tools | length > 0)' || return 0
+  assert_jq "$name" '.result | has("resultType") | not' || return 0
+  pass "$name"
+}
+
+# the modern era maps method-not-found onto HTTP 404; legacy answers 200.
+case_modern_unknown_method() {
+  local name="modern unknown method -> 404 method not found"
+  post "$name" 404 "{\"jsonrpc\":\"2.0\",\"id\":25,\"method\":\"resources/list\",\"params\":{$MODERN_META}}" || return 0
+  assert_jq "$name" '.error.code == -32601' || return 0
+  pass "$name"
+}
+
+# legacy regression: the initialize handshake still selects legacy semantics
+# and never negotiates a modern version.
+case_legacy_initialize() {
+  local name="legacy initialize -> negotiates 2025-11-25"
+  post "$name" 200 '{"jsonrpc":"2.0","id":26,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}' || return 0
+  assert_jq "$name" '.id == 26 and .result.protocolVersion == "2025-11-25"' || return 0
+  assert_jq "$name" '.result.capabilities.tools != null and .result.serverInfo != null' || return 0
+  pass "$name"
+}
+
+# legacy regression: tools/call without any modern marker keeps working and
+# stays unshaped (no resultType).
+case_legacy_tool_call() {
+  local name="legacy tools/call getPetById -> unshaped result"
+  post "$name" 200 '{"jsonrpc":"2.0","id":27,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1}}}' \
+    -H 'api_key: e2e' || return 0
+  assert_jq "$name" '.id == 27 and .result.isError != true' || return 0
+  assert_jq "$name" '.result | has("resultType") | not' || return 0
+  pass "$name"
+}
 
 # scan Envoy + processor logs for silent failures (e.g. ext_proc mutation
 # rejections that do not surface as a curl error).
@@ -290,6 +364,13 @@ case_empty_upstream_body
 case_rebinding_origin
 case_allowed_origin
 case_malformed_json
+case_modern_tools_list
+case_modern_tool_call
+case_modern_unsupported_version
+case_precutover_meta_version
+case_modern_unknown_method
+case_legacy_initialize
+case_legacy_tool_call
 case_log_scan
 case_all_tools_success
 

--- a/extproc_response.go
+++ b/extproc_response.go
@@ -87,10 +87,14 @@ func rerouteWithBodyMutation(host string, method string, path string, body []byt
 }
 
 func newImmediateBodyResponse(body []byte) []*extProcPb.ProcessingResponse {
+	return newImmediateBodyResponseWithStatus(body, typev3.StatusCode_OK)
+}
+
+func newImmediateBodyResponseWithStatus(body []byte, status typev3.StatusCode) []*extProcPb.ProcessingResponse {
 	return immediateResponse(&extProcPb.ImmediateResponse{
 		Body: body,
 		Status: &typev3.HttpStatus{
-			Code: typev3.StatusCode_OK,
+			Code: status,
 		},
 		Headers: &extProcPb.HeaderMutation{
 			SetHeaders: appendHeader(nil, "content-type", "application/json"),

--- a/mcp.go
+++ b/mcp.go
@@ -1,23 +1,187 @@
 package envoy_mcp_openapi_processor
 
-import "slices"
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
 
-const (
-	v20250618     = "2025-06-18"
-	v20251125     = "2025-11-25"
-	latestVersion = v20251125
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const (
+	v20250618 = "2025-06-18"
+	v20251125 = "2025-11-25"
+	v20260728 = "2026-07-28"
+	// firstModernVersion is the first revision that drops the handshake in favor
+	// of a protocol version on every request; everything before it is legacy.
+	firstModernVersion = v20260728
+	// latestLegacyVersion is the newest version that still uses the handshake.
+	latestLegacyVersion = v20251125
+)
+
+// supportedProtocolVersions is ordered newest first, which is the order clients
+// see when a version is refused.
 var supportedProtocolVersions = []string{
-	v20250618,
+	v20260728,
 	v20251125,
+	v20250618,
 }
 
-// Version negotiation adopted from modelcontextprotocol/go-sdk.
-// If clientVersion is supported, use it. Otherwise, use the latest supported version.
-func negotiateVersion(clientVersion string) string {
-	if slices.Contains(supportedProtocolVersions, clientVersion) {
+// isModernVersion works because versions are ISO dates, so lexicographic order
+// is chronological. The empty string sorts below every real version.
+func isModernVersion(v string) bool {
+	return v >= firstModernVersion
+}
+
+func isSupportedVersion(v string) bool {
+	return slices.Contains(supportedProtocolVersions, v)
+}
+
+// negotiateLegacyVersion honors the client's version when supported, otherwise
+// falls back to our newest (adopted from modelcontextprotocol/go-sdk). Both
+// outcomes are capped at the legacy era, so a client that asks for a modern
+// version over the handshake gets one it can actually use statefully.
+func negotiateLegacyVersion(clientVersion string) string {
+	if isSupportedVersion(clientVersion) && !isModernVersion(clientVersion) {
 		return clientVersion
 	}
-	return latestVersion
+	return latestLegacyVersion
+}
+
+// protocolEra holds the behavior that differs between generations of the MCP
+// spec. [extProcServer.resolveEra] turns a request's version into an era once,
+// and the rest of the code asks the era instead of comparing versions.
+type protocolEra interface {
+	// serves gates dispatch. A method only another era serves is a "method not
+	// found" here, not an unimplemented one.
+	serves(method string) bool
+	// encodeResult marshals result into this era's JSON-RPC result envelope,
+	// stamping the fields the generation makes mandatory.
+	encodeResult(result any) (json.RawMessage, error)
+	errorStatus(code int64) typev3.StatusCode
+}
+
+// legacyEra serves every revision up to and including [latestLegacyVersion].
+// The client negotiates a version over the initialize handshake, results are
+// plain JSON-RPC, and protocol errors are returned in a 200 response body.
+type legacyEra struct{}
+
+func (legacyEra) serves(method string) bool {
+	switch method {
+	case methodInitialize, methodNotificationsInitialized, methodToolsList, methodToolsCall:
+		return true
+	default:
+		return false
+	}
+}
+
+func (legacyEra) encodeResult(result any) (json.RawMessage, error) {
+	return json.Marshal(result)
+}
+
+// errorStatus is always 200. The legacy era returns every JSON-RPC error,
+// protocol errors included, in the body of a successful HTTP response.
+func (legacyEra) errorStatus(int64) typev3.StatusCode {
+	return typev3.StatusCode_OK
+}
+
+// modernEra serves 2026-07-28 and later. There is no handshake, so the method
+// surface shrinks to the tool calls, and every result is stamped with the
+// revision's envelope fields (changelog Major 2 and Major 8).
+type modernEra struct {
+	serverInfo ServerInfo
+}
+
+func (modernEra) serves(method string) bool {
+	switch method {
+	case methodToolsList, methodToolsCall:
+		return true
+	default:
+		return false
+	}
+}
+
+// encodeResult stamps the 2026-07-28 envelope fields — the required resultType
+// and the serverInfo _meta entry servers SHOULD add — onto the results the
+// methods in [modernEra.serves] produce, and refuses anything else.
+func (e modernEra) encodeResult(result any) (json.RawMessage, error) {
+	switch r := result.(type) {
+	case *callToolResult:
+		if r == nil {
+			break
+		}
+		r.Meta = e.metaWithServerInfo(r.Meta)
+		r.ResultType = resultTypeComplete
+		return json.Marshal(r)
+	case *mcp.ListToolsResult:
+		if r == nil {
+			break
+		}
+		r.SetMeta(e.metaWithServerInfo(r.GetMeta()))
+		r.ResultType = resultTypeComplete
+		return json.Marshal(r)
+	}
+	return nil, fmt.Errorf("modern era cannot encode result %T", result)
+}
+
+// metaWithServerInfo adds the serverInfo entry (SEP-2575), leaving the rest.
+func (e modernEra) metaWithServerInfo(meta map[string]any) map[string]any {
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	meta[mcp.MetaKeyServerInfo] = &mcp.Implementation{
+		Name:    e.serverInfo.Name,
+		Version: e.serverInfo.Version,
+	}
+	return meta
+}
+
+// errorStatus gives the protocol errors the statuses SEP-2575 mandates. Every
+// other JSON-RPC error is an application error and is returned in a 200 body,
+// as in the legacy era.
+func (modernEra) errorStatus(code int64) typev3.StatusCode {
+	switch code {
+	case mcp.CodeUnsupportedProtocolVersion, jsonrpc.CodeInvalidParams:
+		return typev3.StatusCode_BadRequest
+	case jsonrpc.CodeMethodNotFound:
+		return typev3.StatusCode_NotFound
+	default:
+		return typev3.StatusCode_OK
+	}
+}
+
+// resolveEra also reports whether the request may be served. Past the cutover
+// an unsupported version is refused rather than ignored.
+func (s *extProcServer) resolveEra(method string, declared string) (protocolEra, bool) {
+	if method == methodInitialize || method == methodNotificationsInitialized {
+		return legacyEra{}, true
+	}
+	if !isModernVersion(declared) {
+		return legacyEra{}, true
+	}
+	return modernEra{serverInfo: s.serverInfo}, isSupportedVersion(declared)
+}
+
+// metaProtocolVersion returns "" when the entry is absent or malformed.
+func metaProtocolVersion(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var peek struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	if err := json.Unmarshal(params, &peek); err != nil {
+		return ""
+	}
+	raw, ok := peek.Meta[mcp.MetaKeyProtocolVersion]
+	if !ok {
+		return ""
+	}
+	var version string
+	if err := json.Unmarshal(raw, &version); err != nil {
+		return ""
+	}
+	return version
 }

--- a/mcp_handler.go
+++ b/mcp_handler.go
@@ -38,6 +38,7 @@ const (
 	attrJSONRPCDecodeError             = "jsonrpc.decode.error"
 	attrMCPMessageType                 = "mcp.message_type"
 	attrMCPMethod                      = "mcp.method"
+	attrMCPProtocolVersion             = "mcp.protocol_version"
 	attrToolName                       = "tool.name"
 	attrToolIsError                    = "tool.is_error"
 	attrToolErrorReason                = "tool.error.reason"
@@ -66,6 +67,8 @@ type mcpProcResponse struct {
 	// ToolResponseConfig is set alongside Reroute and describes how to translate
 	// the upstream response back into an MCP envelope.
 	ToolResponseConfig *toolResponseConfig
+	// Era is set alongside Reroute, so the response phase need not re-derive it.
+	Era protocolEra
 }
 
 func isHTTPErrorStatus(statusCode int) bool {
@@ -94,12 +97,25 @@ func parseUpstreamStatusCode(headers *corev3.HeaderMap) (int, bool) {
 }
 
 func encodeJSONRPCError(id jsonrpc.ID, code int64, message string) []byte {
+	return encodeJSONRPCErrorWithData(id, code, message, nil)
+}
+
+func encodeJSONRPCErrorWithData(id jsonrpc.ID, code int64, message string, data any) []byte {
+	jsonrpcError := &jsonrpc.Error{
+		Code:    code,
+		Message: message,
+	}
+	if data != nil {
+		dataJSON, err := json.Marshal(data)
+		if err != nil {
+			zap.L().Error("Failed to marshal JSON-RPC error data, omitting it", zap.Error(err))
+		} else {
+			jsonrpcError.Data = dataJSON
+		}
+	}
 	buf, err := jsonrpc.EncodeMessage(&jsonrpc.Response{
-		ID: id,
-		Error: &jsonrpc.Error{
-			Code:    code,
-			Message: message,
-		},
+		ID:    id,
+		Error: jsonrpcError,
 	})
 	if err != nil {
 		zap.L().Error("Failed to encode JSON-RPC error response", zap.Error(err))
@@ -108,33 +124,20 @@ func encodeJSONRPCError(id jsonrpc.ID, code int64, message string) []byte {
 	return buf
 }
 
-func jsonrpcErrorImmediateResponse(span trace.Span, id jsonrpc.ID, code int64, message string) *mcpProcResponse {
+func errorResponse(span trace.Span, era protocolEra, id jsonrpc.ID, code int64, message string, data any) *mcpProcResponse {
 	span.SetStatus(codes.Error, message)
-	return &mcpProcResponse{Id: id, Immediate: newImmediateBodyResponse(encodeJSONRPCError(id, code, message))}
-}
-
-func toolExecutionErrorResponse(span trace.Span, id jsonrpc.ID, clientMessage string, traceReason string) *mcpProcResponse {
-	if traceReason == "" {
-		traceReason = clientMessage
+	return &mcpProcResponse{
+		Id:        id,
+		Immediate: newImmediateBodyResponseWithStatus(encodeJSONRPCErrorWithData(id, code, message, data), era.errorStatus(code)),
 	}
-	span.SetAttributes(
-		attribute.Bool(attrToolIsError, true),
-		attribute.String(attrToolErrorReason, traceReason),
-	)
-	return jsonrpcImmediateResponse(span, id, &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: clientMessage},
-		},
-		IsError: true,
-	})
 }
 
-func jsonrpcImmediateResponse(span trace.Span, id jsonrpc.ID, result any) *mcpProcResponse {
-	resultJSON, err := json.Marshal(result)
+func resultResponse(span trace.Span, era protocolEra, id jsonrpc.ID, result any) *mcpProcResponse {
+	resultJSON, err := era.encodeResult(result)
 	if err != nil {
 		zap.L().Error("Error marshaling JSON-RPC result", zap.Error(err))
 		span.RecordError(err)
-		return jsonrpcErrorImmediateResponse(span, id, jsonrpc.CodeInternalError, "Internal error")
+		return errorResponse(span, era, id, jsonrpc.CodeInternalError, "Internal error", nil)
 	}
 	message, err := jsonrpc.EncodeMessage(&jsonrpc.Response{
 		ID:     id,
@@ -143,25 +146,43 @@ func jsonrpcImmediateResponse(span trace.Span, id jsonrpc.ID, result any) *mcpPr
 	if err != nil {
 		zap.L().Error("Error encoding JSON-RPC response", zap.Error(err))
 		span.RecordError(err)
-		return jsonrpcErrorImmediateResponse(span, id, jsonrpc.CodeInternalError, "Internal error")
+		return errorResponse(span, era, id, jsonrpc.CodeInternalError, "Internal error", nil)
 	}
 	return &mcpProcResponse{Id: id, Immediate: newImmediateBodyResponse(message)}
+}
+
+// toolExecutionErrorResponse reports a failure to build the upstream call as an
+// MCP tool error rather than a JSON-RPC error, so the client sees a tool outcome.
+func toolExecutionErrorResponse(span trace.Span, era protocolEra, id jsonrpc.ID, clientMessage string, traceReason string) *mcpProcResponse {
+	if traceReason == "" {
+		traceReason = clientMessage
+	}
+	span.SetAttributes(
+		attribute.Bool(attrToolIsError, true),
+		attribute.String(attrToolErrorReason, traceReason),
+	)
+	return resultResponse(span, era, id, &callToolResult{
+		Content: newTextContent(clientMessage),
+		IsError: true,
+	})
 }
 
 func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte) *mcpProcResponse {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(attribute.Int(attrBodySize, len(body)))
 
+	// A message that fails to decode has no era, so both refusals below use the
+	// legacy envelope, which returns them in a 200 body.
 	msg, err := jsonrpc.DecodeMessage(body)
 	if err != nil {
 		span.RecordError(err)
 		span.SetAttributes(attribute.String(attrJSONRPCDecodeError, err.Error()))
-		return jsonrpcErrorImmediateResponse(span, jsonrpc.ID{}, jsonrpc.CodeParseError, "Parse error")
+		return errorResponse(span, legacyEra{}, jsonrpc.ID{}, jsonrpc.CodeParseError, "Parse error", nil)
 	}
 	req, ok := msg.(*jsonrpc.Request)
 	if !ok {
 		span.SetAttributes(attribute.String(attrMCPMessageType, "not_request"))
-		return jsonrpcErrorImmediateResponse(span, jsonrpc.ID{}, jsonrpc.CodeInvalidRequest, "Invalid Request")
+		return errorResponse(span, legacyEra{}, jsonrpc.ID{}, jsonrpc.CodeInvalidRequest, "Invalid Request", nil)
 	}
 	span.SetAttributes(
 		semconv.RPCMethod(req.Method),
@@ -169,40 +190,61 @@ func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte) *mcp
 		attribute.String(attrJSONRPCMethod, req.Method),
 		attribute.String(attrMCPMethod, mcpMethodLabel(req.Method)),
 	)
+
+	declared := metaProtocolVersion(req.Params)
+	if declared != "" {
+		span.SetAttributes(attribute.String(attrMCPProtocolVersion, protocolVersionLabel(declared)))
+	}
+
+	era, ok := s.resolveEra(req.Method, declared)
+	if !ok {
+		return errorResponse(span, era, req.ID, mcp.CodeUnsupportedProtocolVersion,
+			fmt.Sprintf("Unsupported protocol version: %s", declared),
+			map[string]any{"supported": supportedProtocolVersions, "requested": declared})
+	}
+	if !era.serves(req.Method) {
+		return errorResponse(span, era, req.ID, jsonrpc.CodeMethodNotFound, "Method not found", nil)
+	}
+
 	switch req.Method {
 	case methodInitialize:
-		return s.handleInitialize(span, req)
+		return s.handleInitialize(span, era, req)
 	case methodNotificationsInitialized:
 		return &mcpProcResponse{Id: req.ID, Immediate: httpStatusResponse(typev3.StatusCode_Accepted)}
 	case methodToolsList:
-		return jsonrpcImmediateResponse(span, req.ID, &mcp.ListToolsResult{Tools: s.registry.Tools()})
+		return resultResponse(span, era, req.ID, &mcp.ListToolsResult{Tools: s.registry.Tools()})
 	case methodToolsCall:
-		return s.handleToolCall(span, req)
+		return s.handleToolCall(span, era, req)
 	default:
-		return jsonrpcErrorImmediateResponse(span, req.ID, jsonrpc.CodeMethodNotFound, "Method not found")
+		return errorResponse(span, era, req.ID, jsonrpc.CodeMethodNotFound, "Method not found", nil)
 	}
 }
 
-// mcpMethodLabel returns the method itself for supported MCP methods and
-// "unknown" otherwise, keeping the span attribute's cardinality bounded.
+func protocolVersionLabel(version string) string {
+	if isSupportedVersion(version) {
+		return version
+	}
+	return "unsupported"
+}
+
+// mcpMethodLabel returns the method itself for any method some era serves and
+// "unknown" otherwise. Deriving it from the eras keeps it in step with them.
 func mcpMethodLabel(method string) string {
-	switch method {
-	case methodInitialize, methodNotificationsInitialized, methodToolsList, methodToolsCall:
+	if (legacyEra{}).serves(method) || (modernEra{}).serves(method) {
 		return method
-	default:
-		return "unknown"
 	}
+	return "unknown"
 }
 
-func (s *extProcServer) handleInitialize(span trace.Span, req *jsonrpc.Request) *mcpProcResponse {
+func (s *extProcServer) handleInitialize(span trace.Span, era protocolEra, req *jsonrpc.Request) *mcpProcResponse {
 	var initializeParams mcp.InitializeParams
 	if err := json.Unmarshal(req.Params, &initializeParams); err != nil {
 		zap.L().Debug("Error unmarshalling initialize request", zap.Error(err))
 		span.RecordError(err)
-		return jsonrpcErrorImmediateResponse(span, req.ID, jsonrpc.CodeInvalidParams, fmt.Sprintf("Invalid params: %v", err))
+		return errorResponse(span, era, req.ID, jsonrpc.CodeInvalidParams, fmt.Sprintf("Invalid params: %v", err), nil)
 	}
-	negotiatedProtocolVersion := negotiateVersion(initializeParams.ProtocolVersion)
-	return jsonrpcImmediateResponse(span, req.ID, &mcp.InitializeResult{
+	negotiatedProtocolVersion := negotiateLegacyVersion(initializeParams.ProtocolVersion)
+	return resultResponse(span, era, req.ID, &mcp.InitializeResult{
 		ProtocolVersion: negotiatedProtocolVersion,
 		ServerInfo: &mcp.Implementation{
 			Name:    s.serverInfo.Name,
@@ -215,24 +257,24 @@ func (s *extProcServer) handleInitialize(span trace.Span, req *jsonrpc.Request) 
 	})
 }
 
-func (s *extProcServer) handleToolCall(span trace.Span, req *jsonrpc.Request) *mcpProcResponse {
+func (s *extProcServer) handleToolCall(span trace.Span, era protocolEra, req *jsonrpc.Request) *mcpProcResponse {
 	var callParams callToolRequestParams
 	if err := json.Unmarshal(req.Params, &callParams); err != nil {
 		zap.L().Error("Error unmarshaling tool call request", zap.Error(err))
 		span.RecordError(err)
-		return jsonrpcErrorImmediateResponse(span, req.ID, jsonrpc.CodeInvalidParams, fmt.Sprintf("Invalid params: %v", err))
+		return errorResponse(span, era, req.ID, jsonrpc.CodeInvalidParams, fmt.Sprintf("Invalid params: %v", err), nil)
 	}
 	span.SetAttributes(attribute.String(attrToolName, callParams.Name))
 
 	toolConfig := s.registry.GetConfig(callParams.Name)
 	if toolConfig == nil {
-		return jsonrpcErrorImmediateResponse(span, req.ID, jsonrpc.CodeInvalidParams, fmt.Sprintf("Unknown tool: %s", callParams.Name))
+		return errorResponse(span, era, req.ID, jsonrpc.CodeInvalidParams, fmt.Sprintf("Unknown tool: %s", callParams.Name), nil)
 	}
 
 	endpointReq, paramErr := newEndpointRequest(toolConfig.Endpoint, callParams.Arguments)
 	if paramErr != nil {
 		clientMessage := fmt.Sprintf("Invalid argument %q: %s", paramErr.paramName, paramErr.reason)
-		return toolExecutionErrorResponse(span, req.ID, clientMessage, fmt.Sprintf("Invalid parameter in=%s, name=%s: %s", paramErr.paramIn, paramErr.paramName, paramErr.reason))
+		return toolExecutionErrorResponse(span, era, req.ID, clientMessage, fmt.Sprintf("Invalid parameter in=%s, name=%s: %s", paramErr.paramIn, paramErr.paramName, paramErr.reason))
 	}
 
 	path := endpointReq.fullPath()
@@ -241,7 +283,7 @@ func (s *extProcServer) handleToolCall(span trace.Span, req *jsonrpc.Request) *m
 	if err != nil {
 		zap.L().Error("Error marshaling request body", zap.Error(err))
 		span.RecordError(err)
-		return toolExecutionErrorResponse(span, req.ID, fmt.Sprintf("Failed to serialize 'body' argument: %v", err), "")
+		return toolExecutionErrorResponse(span, era, req.ID, fmt.Sprintf("Failed to serialize 'body' argument: %v", err), "")
 	}
 
 	span.SetAttributes(
@@ -253,18 +295,19 @@ func (s *extProcServer) handleToolCall(span trace.Span, req *jsonrpc.Request) *m
 		Id:                 req.ID,
 		Reroute:            rerouteWithBodyMutation(toolConfig.Endpoint.Host, strings.ToUpper(toolConfig.Endpoint.Method), path, requestBody, endpointReq.extraHeaders),
 		ToolResponseConfig: &toolConfig.toolResponseConfig,
+		Era:                era,
 	}
 }
 
-func buildMCPResponsePayload(ctx context.Context, jsonrpcID jsonrpc.ID, body []byte, config *toolResponseConfig, errInfo *errorInfo) ([]byte, []*corev3.HeaderValueOption) {
+func buildMCPResponsePayload(ctx context.Context, reqCtx *requestContext, body []byte) ([]byte, []*corev3.HeaderValueOption) {
 	span := trace.SpanFromContext(ctx)
 
-	buf, err := buildMCPResponse(ctx, jsonrpcID, body, config, errInfo)
+	buf, err := buildMCPResponse(ctx, reqCtx, body, httpStatusToErrorInfo(reqCtx.upstreamStatusCode))
 	if err != nil {
 		span.RecordError(err)
 		span.SetAttributes(attribute.String(attrResponseMarshalError, err.Error()))
 		span.SetStatus(codes.Error, "failed to build MCP response")
-		buf = encodeJSONRPCError(jsonrpcID, jsonrpc.CodeInternalError, "Internal error")
+		buf = encodeJSONRPCError(reqCtx.jsonrpcID, jsonrpc.CodeInternalError, "Internal error")
 	}
 
 	headers := appendHeader(nil, "content-type", "application/json")
@@ -274,11 +317,10 @@ func buildMCPResponsePayload(ctx context.Context, jsonrpcID jsonrpc.ID, body []b
 
 // buildEndOfStreamResponse synthesizes an MCP response for a tool call whose
 // upstream returned no body (end_of_stream on the response headers).
-func buildEndOfStreamResponse(ctx context.Context, requestContext *requestContext) []*extProcPb.ProcessingResponse {
-	content := describeEmptyUpstreamResponse(requestContext.upstreamStatusCode)
-	errInfo := httpStatusToErrorInfo(requestContext.upstreamStatusCode)
+func buildEndOfStreamResponse(ctx context.Context, reqCtx *requestContext) []*extProcPb.ProcessingResponse {
+	content := describeEmptyUpstreamResponse(reqCtx.upstreamStatusCode)
 
-	buf, headers := buildMCPResponsePayload(ctx, requestContext.jsonrpcID, []byte(content), requestContext.toolResponseConfig, errInfo)
+	buf, headers := buildMCPResponsePayload(ctx, reqCtx, []byte(content))
 	return newReplacedResponse(headers, buf)
 }
 
@@ -300,31 +342,32 @@ func httpStatusToErrorInfo(statusCode int) *errorInfo {
 	return &errorInfo{fmt.Sprintf("upstream returned error status code %d", statusCode)}
 }
 
-func (s *extProcServer) mcpResponseHandler(ctx context.Context, body []byte, jsonrpcID jsonrpc.ID, config *toolResponseConfig, errInfo *errorInfo) streamedMutation {
+func mcpResponseHandler(ctx context.Context, body []byte, reqCtx *requestContext) streamedMutation {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
 		attribute.Int(attrBodySize, len(body)),
-		attribute.Bool(attrResponseToolCallContextPresent, config != nil),
-		attribute.Bool(attrResponseJSONRPCIDPresent, jsonrpcID.IsValid()),
+		attribute.Bool(attrResponseToolCallContextPresent, reqCtx.toolResponseConfig != nil),
+		attribute.Bool(attrResponseJSONRPCIDPresent, reqCtx.jsonrpcID.IsValid()),
 	)
-	if jsonrpcID.IsValid() {
-		span.SetAttributes(attribute.String(attrJSONRPCID, fmt.Sprint(jsonrpcID.Raw())))
+	if reqCtx.jsonrpcID.IsValid() {
+		span.SetAttributes(attribute.String(attrJSONRPCID, fmt.Sprint(reqCtx.jsonrpcID.Raw())))
 	}
-	buf, headers := buildMCPResponsePayload(ctx, jsonrpcID, body, config, errInfo)
+	buf, headers := buildMCPResponsePayload(ctx, reqCtx, body)
 	return streamedMutation{
 		headers: responseFactory.headerMutation(headers, contentHeaders),
 		body:    buf,
 	}
 }
 
-func buildMCPResponse(ctx context.Context, jsonrpcID jsonrpc.ID, body []byte, config *toolResponseConfig, errorInfo *errorInfo) ([]byte, error) {
+func buildMCPResponse(ctx context.Context, reqCtx *requestContext, body []byte, errorInfo *errorInfo) ([]byte, error) {
 	span := trace.SpanFromContext(ctx)
 	isError := errorInfo != nil
 
-	if !jsonrpcID.IsValid() {
+	if !reqCtx.jsonrpcID.IsValid() {
 		return nil, fmt.Errorf("missing req context information: jsonrpcid")
 	}
 
+	config := reqCtx.toolResponseConfig
 	if config == nil {
 		return nil, fmt.Errorf("missing req context information: tool config ref")
 	}
@@ -346,23 +389,17 @@ func buildMCPResponse(ctx context.Context, jsonrpcID jsonrpc.ID, body []byte, co
 		span.SetAttributes(attribute.String(attrToolErrorReason, errorInfo.traceMessage))
 	}
 
-	result := &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{
-				Text: string(body),
-			},
-		},
-		IsError: isError,
+	result := &callToolResult{
+		Content:           newTextContent(string(body)),
+		StructuredContent: structuredContent,
+		IsError:           isError,
 	}
-	if structuredContent != nil {
-		result.StructuredContent = structuredContent
-	}
-	resultJson, err := json.Marshal(result)
+	resultJson, err := reqCtx.protocolEra().encodeResult(result)
 	if err != nil {
 		return nil, err
 	}
 	message, err := jsonrpc.EncodeMessage(&jsonrpc.Response{
-		ID:     jsonrpcID,
+		ID:     reqCtx.jsonrpcID,
 		Result: resultJson,
 	})
 	if err != nil {

--- a/mcp_handler_fuzz_test.go
+++ b/mcp_handler_fuzz_test.go
@@ -32,6 +32,10 @@ func FuzzMcpRequestHandler(f *testing.F) {
 	f.Add([]byte(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"updatePet","arguments":{"body":{"id":1,"name":"kitty"}}}}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"nonExistentTool","arguments":{}}}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","id":9,"method":"unknown/method","params":{}}`))
+	// Modern (2026-07-28) requests carrying the protocol version in _meta
+	f.Add([]byte(`{"jsonrpc":"2.0","id":11,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`))
+	f.Add([]byte(`{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":"42"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`))
+	f.Add([]byte(`{"jsonrpc":"2.0","id":13,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}`))
 
 	// Seed corpus — malformed / edge-case inputs
 	f.Add([]byte(``))
@@ -83,12 +87,13 @@ func FuzzMcpResponseHandler(f *testing.F) {
 	f.Add([]byte("\x00\xff"), "10")
 	f.Add([]byte(`{"deeply":{"nested":{"object":{"value":true}}}}`), "11")
 
-	server := newFuzzServer(f)
-
+	// No server needed. The response phase is driven by the era and tool config
+	// on the requestContext.
 	f.Fuzz(func(t *testing.T, body []byte, jsonrpcIDStr string) {
 		ctx := context.Background()
 		jsonrpcID, _ := jsonrpc.MakeID(jsonrpcIDStr)
-		// Must not panic regardless of input
-		server.mcpResponseHandler(ctx, body, jsonrpcID, &toolResponseConfig{}, nil)
+		// Must not panic regardless of input, in both eras
+		mcpResponseHandler(ctx, body, &requestContext{jsonrpcID: jsonrpcID, toolResponseConfig: &toolResponseConfig{}, upstreamStatusCode: 200})
+		mcpResponseHandler(ctx, body, &requestContext{jsonrpcID: jsonrpcID, toolResponseConfig: &toolResponseConfig{}, upstreamStatusCode: 200, era: modernEra{}})
 	})
 }

--- a/mcp_handler_jsonrpc_errors_test.go
+++ b/mcp_handler_jsonrpc_errors_test.go
@@ -83,20 +83,15 @@ func TestMcpRequestHandler_JSONRPCErrorCodes(t *testing.T) {
 			assert.Equal(t, int32(200), int32(immediate.GetStatus().GetCode()),
 				"protocol errors should use HTTP 200 with JSON-RPC error body")
 
-			assertJSONRPCErrorBody(t, immediate.GetBody(), tt.wantCode)
-
-			var decoded map[string]any
-			require.NoError(t, json.Unmarshal(immediate.GetBody(), &decoded))
-			errObj := decoded["error"].(map[string]any)
-			actualMsg := errObj["message"].(string)
+			errObj := assertJSONRPCErrorBody(t, immediate.GetBody(), tt.wantCode)
 			if tt.wantMessage != nil {
-				assert.Regexp(t, tt.wantMessage, actualMsg)
+				assert.Regexp(t, tt.wantMessage, errObj["message"])
 			}
 		})
 	}
 }
 
-func assertJSONRPCErrorBody(t *testing.T, body []byte, wantCode int64) {
+func assertJSONRPCErrorBody(t *testing.T, body []byte, wantCode int64) map[string]any {
 	t.Helper()
 
 	var decoded map[string]any
@@ -114,4 +109,6 @@ func assertJSONRPCErrorBody(t *testing.T, body []byte, wantCode int64) {
 
 	_, hasMsg := errObj["message"].(string)
 	assert.True(t, hasMsg, "'error.message' should be a string")
+
+	return errObj
 }

--- a/mcp_handler_modern_test.go
+++ b/mcp_handler_modern_test.go
@@ -1,0 +1,198 @@
+package envoy_mcp_openapi_processor
+
+import (
+	"context"
+	"testing"
+
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const modernMeta = `"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}`
+
+func TestModernRequests_HappyPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tools/list carries modern result fields", func(t *testing.T) {
+		t.Parallel()
+		server := newTestServer(t, "testdata/petstore.openapi.yaml")
+		server.serverInfo = ServerInfo{Name: "test-server", Version: "1.2.3"}
+
+		requestBody := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{` + modernMeta + `}}`)
+
+		response := server.mcpRequestHandler(context.Background(), requestBody)
+		immediate := requireImmediateResponse(t, response.Immediate)
+		assert.Equal(t, typev3.StatusCode_OK, immediate.GetStatus().GetCode())
+
+		_, result := decodeJSONRPCResult(t, immediate.GetBody())
+		assert.Equal(t, "complete", result["resultType"], "resultType")
+		assertServerInfoMeta(t, result, "test-server", "1.2.3")
+
+		tools, ok := result["tools"].([]any)
+		require.True(t, ok, "result should contain 'tools'")
+		require.NotEmpty(t, tools)
+	})
+
+	t.Run("tools/call reroutes and records the resolved era", func(t *testing.T) {
+		t.Parallel()
+		server := newTestServer(t, "testdata/petstore.openapi.yaml")
+
+		requestBody := []byte(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},` + modernMeta + `}}`)
+
+		response := server.mcpRequestHandler(context.Background(), requestBody)
+		require.NotNil(t, response.Reroute, "modern tools/call should reroute upstream")
+		assert.IsType(t, modernEra{}, response.Era)
+	})
+
+	t.Run("initialize never negotiates a modern version", func(t *testing.T) {
+		t.Parallel()
+		server := newTestServer(t, "testdata/petstore.openapi.yaml")
+
+		requestBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},` + modernMeta + `}}`)
+
+		response := server.mcpRequestHandler(context.Background(), requestBody)
+		immediate := requireImmediateResponse(t, response.Immediate)
+
+		_, result := decodeJSONRPCResult(t, immediate.GetBody())
+		assert.Equal(t, latestLegacyVersion, result["protocolVersion"])
+		assert.NotContains(t, result, "resultType", "handshake result stays legacy-shaped")
+	})
+}
+
+func TestModernRequests_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		requestBody    string
+		wantHTTPStatus typev3.StatusCode
+		wantCode       int64
+		wantMessage    string
+	}{
+		{
+			name:           "unknown method gets 404",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{` + modernMeta + `}}`,
+			wantHTTPStatus: typev3.StatusCode_NotFound,
+			wantCode:       jsonrpc.CodeMethodNotFound,
+			wantMessage:    "Method not found",
+		},
+		{
+			name:           "unknown tool gets 400",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"noSuchTool","arguments":{},` + modernMeta + `}}`,
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       jsonrpc.CodeInvalidParams,
+			wantMessage:    "Unknown tool: noSuchTool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := newTestServer(t, "testdata/petstore.openapi.yaml")
+
+			response := server.mcpRequestHandler(context.Background(), []byte(tt.requestBody))
+			require.NotNil(t, response)
+			immediate := requireImmediateResponse(t, response.Immediate)
+			assert.Equal(t, tt.wantHTTPStatus, immediate.GetStatus().GetCode(), "HTTP status")
+
+			errObj := assertJSONRPCErrorBody(t, immediate.GetBody(), tt.wantCode)
+			if tt.wantMessage != "" {
+				assert.Equal(t, tt.wantMessage, errObj["message"])
+			}
+		})
+	}
+}
+
+func TestModernRequests_PreCutoverMetaVersionIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	legacyMeta := `"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}`
+
+	t.Run("tools/list is served unshaped", func(t *testing.T) {
+		t.Parallel()
+		server := newTestServer(t, "testdata/petstore.openapi.yaml")
+
+		response := server.mcpRequestHandler(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{`+legacyMeta+`}}`))
+		immediate := requireImmediateResponse(t, response.Immediate)
+		assert.Equal(t, typev3.StatusCode_OK, immediate.GetStatus().GetCode())
+
+		_, result := decodeJSONRPCResult(t, immediate.GetBody())
+		assert.NotContains(t, result, "resultType", "an ignored declaration must not shape the result")
+		assert.NotContains(t, result, "_meta")
+	})
+
+	t.Run("tools/call reroutes on the legacy era", func(t *testing.T) {
+		t.Parallel()
+		server := newTestServer(t, "testdata/petstore.openapi.yaml")
+
+		response := server.mcpRequestHandler(context.Background(), []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},`+legacyMeta+`}}`))
+		require.NotNil(t, response.Reroute)
+		assert.IsType(t, legacyEra{}, response.Era)
+	})
+}
+
+func TestModernRequests_UnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, "testdata/petstore.openapi.yaml")
+	requestBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}`)
+
+	response := server.mcpRequestHandler(context.Background(), requestBody)
+	immediate := requireImmediateResponse(t, response.Immediate)
+	assert.Equal(t, typev3.StatusCode_BadRequest, immediate.GetStatus().GetCode(), "HTTP status")
+
+	errObj := assertJSONRPCErrorBody(t, immediate.GetBody(), mcp.CodeUnsupportedProtocolVersion)
+	assert.Equal(t, "Unsupported protocol version: 2099-01-01", errObj["message"])
+	data, ok := errObj["data"].(map[string]any)
+	require.True(t, ok, "error should carry structured data")
+	assert.Equal(t, "2099-01-01", data["requested"])
+	assert.Equal(t, []any{"2026-07-28", "2025-11-25", "2025-06-18"}, data["supported"])
+}
+
+func TestToolCallResponseShapingPerEra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		era        protocolEra
+		wantModern bool
+	}{
+		{
+			name:       "modern response carries resultType and serverInfo",
+			era:        modernEra{serverInfo: ServerInfo{Name: "test-server", Version: "1.2.3"}},
+			wantModern: true,
+		},
+		{name: "legacy response stays unshaped", era: legacyEra{}, wantModern: false},
+		{name: "an unset era defaults to legacy", era: nil, wantModern: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reqCtx := &requestContext{
+				jsonrpcID:          mustMakeID("shape-1"),
+				toolResponseConfig: &toolResponseConfig{},
+				upstreamStatusCode: 200,
+				era:                tt.era,
+			}
+			mutation := mcpResponseHandler(context.Background(), []byte(`{"status":"ok"}`), reqCtx)
+			require.NotNil(t, mutation.headers)
+
+			_, result := decodeJSONRPCResult(t, mutation.body)
+			if tt.wantModern {
+				assert.Equal(t, "complete", result["resultType"])
+				assertServerInfoMeta(t, result, "test-server", "1.2.3")
+			} else {
+				assert.NotContains(t, result, "resultType")
+				assert.NotContains(t, result, "_meta")
+			}
+			content, ok := result["content"].([]any)
+			require.True(t, ok, "result should contain 'content'")
+			require.NotEmpty(t, content)
+		})
+	}
+}

--- a/mcp_handler_protocol_translation_test.go
+++ b/mcp_handler_protocol_translation_test.go
@@ -290,7 +290,7 @@ func TestPetstoreProtocolTranslation_OperationCases(t *testing.T) {
 			require.NotNil(t, reqResult.Reroute)
 			assertRequestTranslation(t, reqResult, tc.requestExpectation)
 
-			respResult := server.mcpResponseHandler(context.Background(), tc.upstreamResponse, reqResult.Id, &toolConfig.toolResponseConfig, nil)
+			respResult := mcpResponseHandler(context.Background(), tc.upstreamResponse, &requestContext{jsonrpcID: reqResult.Id, toolResponseConfig: &toolConfig.toolResponseConfig, upstreamStatusCode: 200})
 			require.NotNil(t, respResult.headers)
 			assertResponseTranslation(t, frame(respResult, responseFactory, false), tc.upstreamResponse, tc.responseExpectation)
 		})
@@ -369,13 +369,12 @@ func TestPetstoreProtocolTranslation_StructuredOutputDowngradesForInvalidJSON(t 
 	})
 	require.NoError(t, err)
 
-	server := &extProcServer{registry: registry}
 	toolConfig := registry.GetConfig("addPet")
 	require.NotNil(t, toolConfig)
 	require.True(t, toolConfig.toolResponseConfig.UseStructuredOutput)
 
 	upstreamBody := []byte(`not-json-upstream-body`)
-	response := server.mcpResponseHandler(context.Background(), upstreamBody, mustMakeID("test-id-structured-downgrade"), &toolConfig.toolResponseConfig, nil)
+	response := mcpResponseHandler(context.Background(), upstreamBody, &requestContext{jsonrpcID: mustMakeID("test-id-structured-downgrade"), toolResponseConfig: &toolConfig.toolResponseConfig, upstreamStatusCode: 200})
 	require.NotNil(t, response.headers)
 
 	assertResponseTranslation(t, frame(response, responseFactory, false), upstreamBody, responseExpectation{
@@ -394,14 +393,13 @@ func TestPetstoreProtocolTranslation_ResponseBodyMarksAPIFailuresAsToolErrors(t 
 	})
 	require.NoError(t, err)
 
-	server := &extProcServer{registry: registry}
 	toolConfig := registry.GetConfig("getPetById")
 	require.NotNil(t, toolConfig)
 
 	for _, upstreamStatus := range []int{500, 0} {
 		t.Run(fmt.Sprintf("status_%d", upstreamStatus), func(t *testing.T) {
 			upstreamBody := []byte(`{"message":"upstream failed"}`)
-			response := server.mcpResponseHandler(context.Background(), upstreamBody, mustMakeID("test-id-api-failure"), &toolConfig.toolResponseConfig, httpStatusToErrorInfo(upstreamStatus))
+			response := mcpResponseHandler(context.Background(), upstreamBody, &requestContext{jsonrpcID: mustMakeID("test-id-api-failure"), toolResponseConfig: &toolConfig.toolResponseConfig, upstreamStatusCode: upstreamStatus})
 			require.NotNil(t, response.headers)
 
 			assertResponseTranslation(t, frame(response, responseFactory, false), upstreamBody, responseExpectation{

--- a/mcp_handler_tracing_test.go
+++ b/mcp_handler_tracing_test.go
@@ -146,6 +146,35 @@ func TestMcpRequestHandler_Tracing(t *testing.T) {
 	}
 }
 
+func TestMcpRequestHandler_ProtocolVersionAttributeIsBounded(t *testing.T) {
+	tests := []struct {
+		name     string
+		declared string
+		want     string
+	}{
+		{name: "supported version recorded verbatim", declared: v20260728, want: v20260728},
+		{name: "unsupported version bucketed", declared: "2026-07-29", want: "unsupported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracer, spanRecorder := setupTestTracer()
+			server := newTestServer(t, "testdata/petstore.openapi.yaml")
+			spanName := "test_" + tt.name
+			ctx, rootSpan := tracer.Start(context.Background(), spanName)
+
+			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":%q}}}`, tt.declared)
+
+			server.mcpRequestHandler(ctx, []byte(body))
+			rootSpan.End()
+
+			testSpan, found := findSpanByName(spanRecorder.Ended(), spanName)
+			require.True(t, found, "span '%s' not found", spanName)
+			assert.Equal(t, tt.want, getSpanAttribute(testSpan, attrMCPProtocolVersion), "mcp.protocol_version")
+		})
+	}
+}
+
 func TestMcpResponseHandler_Tracing(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -189,23 +218,23 @@ func TestMcpResponseHandler_Tracing(t *testing.T) {
 			jsonrpcID:           mustMakeID("test-id-004"),
 			IsError:             true,
 			wantStatusCode:      codes.Unset,
-			wantToolErrorReason: `test reason`,
+			wantToolErrorReason: `upstream returned error status code 404`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tracer, spanRecorder := setupTestTracer()
-			server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
 			spanName := "test_" + tt.name
 			ctx, rootSpan := tracer.Start(context.Background(), spanName)
 
-			var errInfo *errorInfo
+			upstreamStatusCode := 200
 			if tt.IsError {
-				errInfo = &errorInfo{"test reason"}
+				upstreamStatusCode = 404
 			}
-			resp := server.mcpResponseHandler(ctx, []byte(tt.responseBody), tt.jsonrpcID, &toolResponseConfig{}, errInfo)
+			reqCtx := &requestContext{jsonrpcID: tt.jsonrpcID, toolResponseConfig: &toolResponseConfig{}, upstreamStatusCode: upstreamStatusCode}
+			resp := mcpResponseHandler(ctx, []byte(tt.responseBody), reqCtx)
 			assert.NotNil(t, resp.headers, "Expected non-nil response")
 
 			rootSpan.End()
@@ -258,11 +287,10 @@ func TestMcpResponseHandler_ErrorTracing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tracer, spanRecorder := setupTestTracer()
-			server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
 			spanName := "test_" + tt.name
 			ctx, span := tracer.Start(context.Background(), spanName)
-			resp := server.mcpResponseHandler(ctx, []byte(`{"status":"ok"}`), tt.jsonrpcID, tt.config, nil)
+			resp := mcpResponseHandler(ctx, []byte(`{"status":"ok"}`), &requestContext{jsonrpcID: tt.jsonrpcID, toolResponseConfig: tt.config, upstreamStatusCode: 200})
 			span.End()
 
 			require.NotNil(t, resp.headers)

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -1,12 +1,17 @@
 package envoy_mcp_openapi_processor
 
 import (
+	"encoding/json"
 	"testing"
 
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNegotiateVersion(t *testing.T) {
+func TestNegotiateLegacyVersion(t *testing.T) {
 	tests := []struct {
 		name          string
 		clientVersion string
@@ -20,13 +25,229 @@ func TestNegotiateVersion(t *testing.T) {
 		{
 			name:          "defaults to latest supported version",
 			clientVersion: "2024-11-05",
-			want:          latestVersion,
+			want:          latestLegacyVersion,
+		},
+		{
+			name:          "never negotiates a modern version on the legacy handshake",
+			clientVersion: v20260728,
+			want:          latestLegacyVersion,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, negotiateVersion(test.clientVersion))
+			assert.Equal(t, test.want, negotiateLegacyVersion(test.clientVersion))
+		})
+	}
+}
+
+func TestIsModernVersion(t *testing.T) {
+	assert.False(t, isModernVersion(v20250618))
+	assert.False(t, isModernVersion(v20251125))
+	assert.False(t, isModernVersion(""))
+	assert.True(t, isModernVersion(v20260728))
+	assert.True(t, isModernVersion("2027-01-01"))
+}
+
+func TestResolveEra(t *testing.T) {
+	server := &extProcServer{serverInfo: ServerInfo{Name: "srv", Version: "1"}}
+
+	tests := []struct {
+		name     string
+		method   string
+		declared string
+		wantEra  protocolEra
+		wantOK   bool
+	}{
+		{name: "no declared version is legacy", method: methodToolsList, wantEra: legacyEra{}, wantOK: true},
+		{name: "initialize is legacy", method: methodInitialize, wantEra: legacyEra{}, wantOK: true},
+		{name: "initialize ignores a declared version", method: methodInitialize, declared: v20260728, wantEra: legacyEra{}, wantOK: true},
+		{name: "notifications/initialized is legacy", method: methodNotificationsInitialized, declared: v20260728, wantEra: legacyEra{}, wantOK: true},
+		{name: "supported modern version", method: methodToolsList, declared: v20260728, wantEra: modernEra{}, wantOK: true},
+		// A pre-cutover declaration is a legacy client restating its negotiated
+		// version, so it is ignored and the request is served.
+		{name: "pre-cutover version is ignored", method: methodToolsList, declared: v20251125, wantEra: legacyEra{}, wantOK: true},
+		{name: "unsupported older version is ignored", method: methodToolsList, declared: "2024-11-05", wantEra: legacyEra{}, wantOK: true},
+		// Past the cutover the declaration is binding, so an unknown version
+		// there is refused rather than ignored.
+		{name: "unknown future version is refused", method: methodToolsList, declared: "2099-01-01", wantEra: modernEra{}, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			era, ok := server.resolveEra(tt.method, tt.declared)
+			assert.IsType(t, tt.wantEra, era)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+func TestProtocolEraMethodSurface(t *testing.T) {
+	tests := []struct {
+		method       string
+		legacyServes bool
+		modernServes bool
+	}{
+		{method: methodToolsList, legacyServes: true, modernServes: true},
+		{method: methodToolsCall, legacyServes: true, modernServes: true},
+		// The handshake exists only in the legacy era.
+		{method: methodInitialize, legacyServes: true, modernServes: false},
+		{method: methodNotificationsInitialized, legacyServes: true, modernServes: false},
+		{method: "resources/list", legacyServes: false, modernServes: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			assert.Equal(t, tt.legacyServes, legacyEra{}.serves(tt.method), "legacy")
+			assert.Equal(t, tt.modernServes, modernEra{}.serves(tt.method), "modern")
+		})
+	}
+}
+
+func TestProtocolEraErrorStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       int64
+		wantLegacy typev3.StatusCode
+		wantModern typev3.StatusCode
+	}{
+		{name: "unsupported protocol version", code: mcp.CodeUnsupportedProtocolVersion, wantLegacy: typev3.StatusCode_OK, wantModern: typev3.StatusCode_BadRequest},
+		{name: "method not found", code: jsonrpc.CodeMethodNotFound, wantLegacy: typev3.StatusCode_OK, wantModern: typev3.StatusCode_NotFound},
+		{name: "invalid params", code: jsonrpc.CodeInvalidParams, wantLegacy: typev3.StatusCode_OK, wantModern: typev3.StatusCode_BadRequest},
+		{name: "parse error", code: jsonrpc.CodeParseError, wantLegacy: typev3.StatusCode_OK, wantModern: typev3.StatusCode_OK},
+		{name: "internal error", code: jsonrpc.CodeInternalError, wantLegacy: typev3.StatusCode_OK, wantModern: typev3.StatusCode_OK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantLegacy, legacyEra{}.errorStatus(tt.code), "legacy")
+			assert.Equal(t, tt.wantModern, modernEra{}.errorStatus(tt.code), "modern")
+		})
+	}
+}
+
+func TestProtocolEraEncodeResult(t *testing.T) {
+	// The modern era stamps the value it is handed, so each era gets a fresh
+	// result; a shared one would make the assertions order-dependent.
+	tests := []struct {
+		name      string
+		newResult func() any
+	}{
+		{name: "tools/call", newResult: func() any {
+			return &callToolResult{Content: newTextContent("hi")}
+		}},
+		{name: "tools/list", newResult: func() any {
+			return &mcp.ListToolsResult{Tools: []*mcp.Tool{{Name: "tool"}}}
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacyJSON, err := legacyEra{}.encodeResult(tt.newResult())
+			require.NoError(t, err)
+			var legacyObj map[string]any
+			require.NoError(t, json.Unmarshal(legacyJSON, &legacyObj))
+			assert.NotContains(t, legacyObj, "resultType")
+			assert.NotContains(t, legacyObj, "_meta")
+
+			era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
+			modernJSON, err := era.encodeResult(tt.newResult())
+			require.NoError(t, err)
+			var modernObj map[string]any
+			require.NoError(t, json.Unmarshal(modernJSON, &modernObj))
+			assert.Equal(t, "complete", modernObj["resultType"])
+			assertServerInfoMeta(t, modernObj, "srv", "1.2.3")
+		})
+	}
+}
+
+func TestModernEraEncodeResultKeepsExistingMeta(t *testing.T) {
+	result := &callToolResult{
+		Content:    newTextContent("hi"),
+		resultMeta: resultMeta{Meta: map[string]any{"vendor/key": "kept"}},
+	}
+
+	era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
+	modernJSON, err := era.encodeResult(result)
+	require.NoError(t, err)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(modernJSON, &obj))
+	assert.Equal(t, "complete", obj["resultType"])
+	assertServerInfoMeta(t, obj, "srv", "1.2.3")
+	meta, ok := obj["_meta"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "kept", meta["vendor/key"])
+}
+
+// TestModernEraEncodeResultRefusesUnstampable also covers nil. Every result is
+// a pointer, so a nil one still carries its type into the interface and only
+// fails when dereferenced.
+func TestModernEraEncodeResultRefusesUnstampable(t *testing.T) {
+	era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
+
+	tests := []struct {
+		name   string
+		result any
+	}{
+		{name: "untyped nil", result: nil},
+		{name: "nil tools/call result", result: (*callToolResult)(nil)},
+		{name: "nil tools/list result", result: (*mcp.ListToolsResult)(nil)},
+		// initialize is legacy-only, so its result never reaches this era.
+		{name: "result of a method the era does not serve", result: &mcp.InitializeResult{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := era.encodeResult(tt.result)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot encode result")
+		})
+	}
+}
+
+// TestCallToolResultDecodesAsSDKResult is why the sdk stays a dependency: it
+// validates the bytes we emit rather than producing them.
+func TestCallToolResultDecodesAsSDKResult(t *testing.T) {
+	era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
+	encoded, err := era.encodeResult(&callToolResult{
+		Content:           newTextContent("body"),
+		StructuredContent: json.RawMessage(`{"count":42}`),
+		IsError:           true,
+	})
+	require.NoError(t, err)
+
+	var decoded mcp.CallToolResult
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+	require.Len(t, decoded.Content, 1)
+	text, ok := decoded.Content[0].(*mcp.TextContent)
+	require.True(t, ok, "content should decode as text content")
+	assert.Equal(t, "body", text.Text)
+	assert.True(t, decoded.IsError)
+	// Decoded through any, so the count arrives as a float64.
+	assert.Equal(t, map[string]any{"count": float64(42)}, decoded.StructuredContent)
+	assertServerInfoMeta(t, map[string]any{"_meta": map[string]any(decoded.GetMeta())}, "srv", "1.2.3")
+}
+
+func TestMetaProtocolVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{name: "declared version", params: `{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`, want: v20260728},
+		{name: "no params", params: ``},
+		{name: "no meta", params: `{"name":"x"}`},
+		{name: "meta without the version key", params: `{"_meta":{"other":"x"}}`},
+		{name: "non-string version", params: `{"_meta":{"io.modelcontextprotocol/protocolVersion":42}}`},
+		{name: "meta is not an object", params: `{"_meta":"bad"}`},
+		{name: "params are not an object", params: `"bad"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, metaProtocolVersion(json.RawMessage(tt.params)))
 		})
 	}
 }

--- a/result.go
+++ b/result.go
@@ -1,0 +1,39 @@
+package envoy_mcp_openapi_processor
+
+import "encoding/json"
+
+// resultTypeComplete is the only result type this server produces. It answers
+// from the upstream API and never asks the client for further input. Untyped so
+// it assigns to go-sdk's unexported resultType on [mcp.ListToolsResult] too.
+const resultTypeComplete = "complete"
+
+// resultMeta holds the envelope fields the 2026-07-28 revision defines on every
+// result. Both are omitempty, so a result the legacy era stamps nothing on
+// encodes as it did before the era split.
+type resultMeta struct {
+	Meta       map[string]any `json:"_meta,omitempty"`
+	ResultType string         `json:"resultType,omitempty"`
+}
+
+// callToolResult mirrors [mcp.CallToolResult] minus the members a proxy never
+// produces. It is ours rather than the sdk's because the sdk seals resultType
+// behind an unexported field and a custom MarshalJSON.
+type callToolResult struct {
+	resultMeta
+	Content []textContent `json:"content"`
+	// StructuredContent is the upstream response body, forwarded verbatim when
+	// the tool declares an output schema.
+	StructuredContent json.RawMessage `json:"structuredContent,omitempty"`
+	IsError           bool            `json:"isError,omitempty"`
+}
+
+// textContent is the only content kind this server emits. Every tool result is
+// an upstream HTTP response body, reported as text.
+type textContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func newTextContent(text string) []textContent {
+	return []textContent{{Type: "text", Text: text}}
+}

--- a/stream_state.go
+++ b/stream_state.go
@@ -53,6 +53,18 @@ type requestContext struct {
 	jsonrpcID          jsonrpc.ID
 	toolResponseConfig *toolResponseConfig
 	upstreamStatusCode int
+	// era is set on the request path; read it through
+	// [requestContext.protocolEra], which defaults it.
+	era protocolEra
+}
+
+// protocolEra defaults to legacy, so a context built without one behaves like a
+// pre-2026 request.
+func (rc *requestContext) protocolEra() protocolEra {
+	if rc.era == nil {
+		return legacyEra{}
+	}
+	return rc.era
 }
 
 // isToolCall reports whether this cycle's request was a tool call the
@@ -166,6 +178,7 @@ func (st *stateBufferingRequest) finalize(ctx context.Context, strm *stream, has
 	reqCtx := requestContext{
 		jsonrpcID:          handlerResult.Id,
 		toolResponseConfig: handlerResult.ToolResponseConfig,
+		era:                handlerResult.Era,
 	}
 
 	// A reroute streams the rewritten request body (framed here with trailers if
@@ -242,7 +255,7 @@ func (st *stateBufferingResponse) finalize(ctx context.Context, strm *stream, ha
 	)
 	defer span.End()
 
-	mutation := strm.server.mcpResponseHandler(ctx, strm.buf, st.request.jsonrpcID, st.request.toolResponseConfig, httpStatusToErrorInfo(st.request.upstreamStatusCode))
+	mutation := mcpResponseHandler(ctx, strm.buf, &st.request)
 	reps := frame(mutation, responseFactory, hasTrailers)
 	return &stateAwaitingRequestHeaders{}, reps, nil
 }

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -2,12 +2,16 @@ package envoy_mcp_openapi_processor
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -70,6 +74,24 @@ func requireResponseHeadersResponse(t *testing.T, reps []*extProcPb.ProcessingRe
 func requireImmediateResponse(t *testing.T, reps []*extProcPb.ProcessingResponse) *extProcPb.ImmediateResponse {
 	t.Helper()
 	return findResponse(t, reps, "immediate response", func(r *extProcPb.ProcessingResponse) bool { return r.GetImmediateResponse() != nil }).GetImmediateResponse()
+}
+
+func decodeJSONRPCResult(t *testing.T, body []byte) (envelope map[string]any, result map[string]any) {
+	t.Helper()
+	require.NoError(t, json.Unmarshal(body, &envelope), "response body should be valid JSON")
+	result, ok := envelope["result"].(map[string]any)
+	require.True(t, ok, "response should contain a 'result' object, got: %s", body)
+	return envelope, result
+}
+
+func assertServerInfoMeta(t *testing.T, result map[string]any, wantName, wantVersion string) {
+	t.Helper()
+	meta, ok := result["_meta"].(map[string]any)
+	require.True(t, ok, "modern result should carry _meta")
+	serverInfo, ok := meta[mcp.MetaKeyServerInfo].(map[string]any)
+	require.True(t, ok, "_meta should carry %s", mcp.MetaKeyServerInfo)
+	assert.Equal(t, wantName, serverInfo["name"])
+	assert.Equal(t, wantVersion, serverInfo["version"])
 }
 
 func collectResponseBodyBytes(t *testing.T, reps []*extProcPb.ProcessingResponse) []byte {


### PR DESCRIPTION
The 2026-07-28 revision removes the initialize handshake: every request
carries its protocol version in params._meta, and every result carries
serverInfo and a required resultType (changelog Major 2 and Major 8).

Each request resolves once into a protocolEra that owns its generation's
method surface, result envelope and error statuses. A pre-cutover _meta
version is a legacy client restating what it negotiated and is ignored;
from the cutover on the declaration is binding, so an unsupported version
is refused with HTTP 400 and UnsupportedProtocolVersion (-32022), and an
unknown method answers 404. The handshake itself stays legacy and never
negotiates a modern version.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>