### PR TITLE
Validate the mirrored MCP request headers on modern requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ disjoint entry points, so every request selects one unambiguously:
 - **Legacy era (`2025-06-18`, `2025-11-25`)**: the client starts with the `initialize` handshake and declares no
   version on subsequent requests. Version negotiation never yields a modern version, so a client that asks for
   one over the handshake is answered with a version it can actually use statefully.
-- **Modern era (`2026-07-28`)**: there is no handshake, and every request carries its protocol version in
-  `params._meta` (`io.modelcontextprotocol/protocolVersion`). Results carry `resultType` and the serverInfo
-  `_meta` entry, and an unknown method answers HTTP 404 rather than the legacy 200.
+- **Modern era (`2026-07-28`)**: there is no handshake. Every request carries its protocol version in
+  `params._meta` (`io.modelcontextprotocol/protocolVersion`) and mirrors it in the `MCP-Protocol-Version` header,
+  alongside `Mcp-Method` (and `Mcp-Name` for `tools/call`). Those headers are validated against the JSON-RPC body
+  and mismatches are refused with HTTP 400 and JSON-RPC error `-32020`. Results carry `resultType` and the
+  serverInfo `_meta` entry, and an unknown method answers HTTP 404 rather than the legacy 200.
 
 ## OpenTelemetry
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -177,15 +177,13 @@ case_malformed_json() {
 }
 
 # --- 2026-07-28 (modern era) probes ---
-#
-# Modern requests are stateless: there is no handshake, and every request
-# carries its protocol version in params._meta.
 
 MODERN_META='"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}'
 
 case_modern_tools_list() {
   local name="modern tools/list -> shaped result"
-  post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/list\",\"params\":{$MODERN_META}}" || return 0
+  post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/list\",\"params\":{$MODERN_META}}" \
+    -H 'MCP-Protocol-Version: 2026-07-28' -H 'Mcp-Method: tools/list' || return 0
   assert_jq "$name" '.id == 21 and .result.resultType == "complete" and (.result.tools | length > 0)' || return 0
   assert_jq "$name" '.result._meta["io.modelcontextprotocol/serverInfo"] != null' || return 0
   pass "$name"
@@ -195,6 +193,7 @@ case_modern_tools_list() {
 case_modern_tool_call() {
   local name="modern tools/call getPetById -> shaped result"
   post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":\"tools/call\",\"params\":{\"name\":\"getPetById\",\"arguments\":{\"petId\":1},$MODERN_META}}" \
+    -H 'MCP-Protocol-Version: 2026-07-28' -H 'Mcp-Method: tools/call' -H 'Mcp-Name: getPetById' \
     -H 'api_key: e2e' || return 0
   assert_jq "$name" '.id == 22 and .result.isError != true' || return 0
   assert_jq "$name" '.result.resultType == "complete"' || return 0
@@ -204,7 +203,8 @@ case_modern_tool_call() {
 
 case_modern_unsupported_version() {
   local name="unsupported protocol version -> 400 with supported list"
-  post "$name" 400 '{"jsonrpc":"2.0","id":24,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}' || return 0
+  post "$name" 400 '{"jsonrpc":"2.0","id":24,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}' \
+    -H 'MCP-Protocol-Version: 2099-01-01' -H 'Mcp-Method: tools/list' || return 0
   assert_jq "$name" '.error.code == -32022' || return 0
   assert_jq "$name" '.error.data.supported | index("2026-07-28") != null' || return 0
   assert_jq "$name" '.error.data.requested == "2099-01-01"' || return 0
@@ -222,10 +222,30 @@ case_precutover_meta_version() {
   pass "$name"
 }
 
+# a modern MCP-Protocol-Version header selects the era on its own, so a request
+# that sends the header but omits the _meta entry gets a mismatch error instead
+# of legacy handling.
+case_mirrored_header_without_meta() {
+  local name="modern header without _meta -> 400 header mismatch"
+  post "$name" 400 '{"jsonrpc":"2.0","id":29,"method":"tools/list","params":{}}' \
+    -H 'MCP-Protocol-Version: 2026-07-28' -H 'Mcp-Method: tools/list' || return 0
+  assert_jq "$name" '.error.code == -32020' || return 0
+  pass "$name"
+}
+
+case_modern_missing_method_header() {
+  local name="modern request without Mcp-Method -> 400 header mismatch"
+  post "$name" 400 "{\"jsonrpc\":\"2.0\",\"id\":23,\"method\":\"tools/list\",\"params\":{$MODERN_META}}" \
+    -H 'MCP-Protocol-Version: 2026-07-28' || return 0
+  assert_jq "$name" '.error.code == -32020' || return 0
+  pass "$name"
+}
+
 # the modern era maps method-not-found onto HTTP 404; legacy answers 200.
 case_modern_unknown_method() {
   local name="modern unknown method -> 404 method not found"
-  post "$name" 404 "{\"jsonrpc\":\"2.0\",\"id\":25,\"method\":\"resources/list\",\"params\":{$MODERN_META}}" || return 0
+  post "$name" 404 "{\"jsonrpc\":\"2.0\",\"id\":25,\"method\":\"resources/list\",\"params\":{$MODERN_META}}" \
+    -H 'MCP-Protocol-Version: 2026-07-28' -H 'Mcp-Method: resources/list' || return 0
   assert_jq "$name" '.error.code == -32601' || return 0
   pass "$name"
 }
@@ -240,7 +260,7 @@ case_legacy_initialize() {
   pass "$name"
 }
 
-# legacy regression: tools/call without any modern marker keeps working and
+# legacy regression: tools/call without any modern headers keeps working and
 # stays unshaped (no resultType).
 case_legacy_tool_call() {
   local name="legacy tools/call getPetById -> unshaped result"
@@ -368,6 +388,8 @@ case_modern_tools_list
 case_modern_tool_call
 case_modern_unsupported_version
 case_precutover_meta_version
+case_mirrored_header_without_meta
+case_modern_missing_method_header
 case_modern_unknown_method
 case_legacy_initialize
 case_legacy_tool_call

--- a/extproc_response.go
+++ b/extproc_response.go
@@ -2,6 +2,7 @@ package envoy_mcp_openapi_processor
 
 import (
 	"net/http"
+	"slices"
 	"strconv"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -12,8 +13,9 @@ import (
 // contentHeaders are the headers which are removed whenever the body is replaced.
 var contentHeaders = []string{"content-length", "content-type"}
 
-// removeOnRoutingHeaders are the headers dropped when the request is mutated and rerouted
-var removeOnRoutingHeaders = []string{"content-length", "content-type", "mcp-protocol-version"}
+// removeOnRoutingHeaders are the headers dropped when the request is mutated
+// and rerouted, so MCP client headers are not forwarded to the upstream API.
+var removeOnRoutingHeaders = []string{"content-length", "content-type", headerMCPProtocolVersion, headerMCPMethod, headerMCPName}
 
 var (
 	// requestFactory provides ext_proc wrappers for request direction
@@ -70,7 +72,7 @@ func appendHeader(headers []*corev3.HeaderValueOption, key string, value string)
 	})
 }
 
-func rerouteWithBodyMutation(host string, method string, path string, body []byte, extraHeaders map[string]string) *streamedMutation {
+func rerouteWithBodyMutation(host string, method string, path string, body []byte, extraHeaders map[string]string, stripHeaders []string) *streamedMutation {
 	count := 3 + len(extraHeaders) // (method, path, authority) + extra headers
 	headers := make([]*corev3.HeaderValueOption, 0, count)
 
@@ -82,7 +84,11 @@ func rerouteWithBodyMutation(host string, method string, path string, body []byt
 	headers = appendHeader(headers, ":path", path)
 	headers = appendHeader(headers, ":authority", host)
 
-	headerMutation := requestFactory.headerMutation(headers, removeOnRoutingHeaders)
+	removeHeaders := removeOnRoutingHeaders
+	if len(stripHeaders) > 0 {
+		removeHeaders = append(slices.Clone(removeOnRoutingHeaders), stripHeaders...)
+	}
+	headerMutation := requestFactory.headerMutation(headers, removeHeaders)
 	return &streamedMutation{headers: headerMutation, body: body}
 }
 

--- a/header_validation.go
+++ b/header_validation.go
@@ -1,0 +1,148 @@
+package envoy_mcp_openapi_processor
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+)
+
+// MCP Streamable HTTP header names, lowercase as delivered by Envoy.
+const (
+	headerMCPProtocolVersion = "mcp-protocol-version"
+	headerMCPMethod          = "mcp-method"
+	headerMCPName            = "mcp-name"
+	headerMCPParamPrefix     = "mcp-param-"
+)
+
+// Base64 sentinel wrapper, per SEP-2243.
+const (
+	base64Prefix = "=?base64?"
+	base64Suffix = "?="
+)
+
+// mcpRequestHeaders carries the headers captured at the request-headers phase
+// into the body phase, where the modern era validates them against the body. An
+// absent header is the empty string.
+type mcpRequestHeaders struct {
+	protocolVersion string
+	method          string
+	name            string
+	// paramHeaderNames lists the mcp-param-* header keys present on the
+	// request, so the reroute path can strip them before forwarding upstream.
+	paramHeaderNames []string
+}
+
+// captureMCPRequestHeaders keeps the first value of a repeated header.
+// http.Header.Get returns the first, so that is the value every other hop reads;
+// keeping the last would let a client pass validation here on a value the
+// previous hop did not see.
+func captureMCPRequestHeaders(headers *corev3.HeaderMap) mcpRequestHeaders {
+	var captured mcpRequestHeaders
+	var protocolVersion, method, name firstHeaderValue
+	for _, h := range headers.GetHeaders() {
+		switch key := strings.ToLower(h.GetKey()); key {
+		case headerMCPProtocolVersion:
+			protocolVersion.capture(h)
+		case headerMCPMethod:
+			method.capture(h)
+		case headerMCPName:
+			name.capture(h)
+		default:
+			if strings.HasPrefix(key, headerMCPParamPrefix) {
+				captured.paramHeaderNames = append(captured.paramHeaderNames, key)
+			}
+		}
+	}
+	captured.protocolVersion = protocolVersion.value
+	captured.method = method.value
+	captured.name = name.value
+	return captured
+}
+
+// firstHeaderValue keeps the first value seen, empty ones included: an empty
+// first value is what Get returns too.
+type firstHeaderValue struct {
+	value string
+	seen  bool
+}
+
+func (f *firstHeaderValue) capture(h *corev3.HeaderValue) {
+	if f.seen {
+		return
+	}
+	f.value, f.seen = headerValue(h), true
+}
+
+func headerValue(h *corev3.HeaderValue) string {
+	return strings.TrimSpace(string(h.GetRawValue()))
+}
+
+// callToolNameParams reads the same `name` as [callToolRequestParams]. Decoding
+// into that type here would materialize the arguments, which hold a tool call's
+// request body, a second time.
+type callToolNameParams struct {
+	Name string `json:"name"`
+}
+
+// validateModernHeaders enforces SEP-2243: the mirrored headers must be present
+// and match the body. metaVersion comes from params._meta, empty if absent.
+func validateModernHeaders(req *jsonrpc.Request, metaVersion string, hdrs mcpRequestHeaders) error {
+	if hdrs.protocolVersion == "" {
+		return errors.New("missing required MCP-Protocol-Version header")
+	}
+	// The body is the source of truth and every 2026-07-28 request carries its
+	// version in _meta, so a header with nothing to match is a mismatch.
+	if metaVersion == "" {
+		return fmt.Errorf("header mismatch: MCP-Protocol-Version header value '%s' has no matching protocolVersion in the body _meta", hdrs.protocolVersion)
+	}
+	if hdrs.protocolVersion != metaVersion {
+		return fmt.Errorf("header mismatch: MCP-Protocol-Version header value '%s' does not match body value '%s'", hdrs.protocolVersion, metaVersion)
+	}
+	if hdrs.method == "" {
+		return errors.New("missing required Mcp-Method header")
+	}
+	if hdrs.method != req.Method {
+		return fmt.Errorf("header mismatch: Mcp-Method header value '%s' does not match body value '%s'", hdrs.method, req.Method)
+	}
+	if req.Method == methodToolsCall {
+		if hdrs.name == "" {
+			return fmt.Errorf("missing required Mcp-Name header for method %q", req.Method)
+		}
+		decodedName, ok := decodeHeaderValue(hdrs.name)
+		if !ok {
+			return errors.New("header mismatch: Mcp-Name header contains invalid Base64 encoding")
+		}
+		var params callToolNameParams
+		if err := json.Unmarshal(req.Params, &params); err != nil || params.Name == "" {
+			return fmt.Errorf("failed to extract name from parameters for method %q", req.Method)
+		}
+		// Report the decoded value, since a Base64-wrapped header cannot be
+		// compared against the body value by eye.
+		if decodedName != params.Name {
+			return fmt.Errorf("header mismatch: Mcp-Name header value '%s' does not match body value '%s'", decodedName, params.Name)
+		}
+	}
+	return nil
+}
+
+// decodeHeaderValue unwraps the SEP-2243 =?base64?...?= sentinel. Registered
+// tool names never need it, since [validateToolName] keeps them header-safe, but
+// a client may wrap anyway. Unwrapped values pass through; false means the
+// wrapped payload is not valid Base64.
+func decodeHeaderValue(headerValue string) (string, bool) {
+	if encoded, ok := strings.CutPrefix(headerValue, base64Prefix); ok {
+		if encoded, ok = strings.CutSuffix(encoded, base64Suffix); ok {
+			decoded, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				return "", false
+			}
+			return string(decoded), true
+		}
+	}
+	return headerValue, true
+}

--- a/header_validation_test.go
+++ b/header_validation_test.go
@@ -1,0 +1,110 @@
+package envoy_mcp_openapi_processor
+
+import (
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaptureMCPRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	headers := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+		{Key: ":authority", RawValue: []byte("localhost")},
+		{Key: "mcp-protocol-version", RawValue: []byte("2026-07-28")},
+		{Key: "mcp-method", RawValue: []byte("tools/call")},
+		{Key: "mcp-name", RawValue: []byte("getPetById")},
+		{Key: "mcp-param-api-key", RawValue: []byte("secret")},
+		{Key: "mcp-param-x-trace", RawValue: []byte("abc")},
+		{Key: "content-type", RawValue: []byte("application/json")},
+	}}
+
+	captured := captureMCPRequestHeaders(headers)
+	assert.Equal(t, "2026-07-28", captured.protocolVersion)
+	assert.Equal(t, "tools/call", captured.method)
+	assert.Equal(t, "getPetById", captured.name)
+	assert.ElementsMatch(t, []string{"mcp-param-api-key", "mcp-param-x-trace"}, captured.paramHeaderNames)
+}
+
+func TestCaptureMCPRequestHeaders_CaseInsensitiveNames(t *testing.T) {
+	t.Parallel()
+
+	headers := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+		{Key: "MCP-Protocol-Version", RawValue: []byte("2026-07-28")},
+		{Key: "Mcp-Method", RawValue: []byte("tools/call")},
+		{Key: "MCP-NAME", RawValue: []byte("getPetById")},
+		{Key: "Mcp-Param-Region", RawValue: []byte("us-west1")},
+	}}
+
+	captured := captureMCPRequestHeaders(headers)
+	assert.Equal(t, "2026-07-28", captured.protocolVersion)
+	assert.Equal(t, "tools/call", captured.method)
+	assert.Equal(t, "getPetById", captured.name)
+	assert.Equal(t, []string{"mcp-param-region"}, captured.paramHeaderNames)
+}
+
+func TestCaptureMCPRequestHeaders_TrimsSurroundingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	headers := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+		{Key: "mcp-name", RawValue: []byte("  getPetById ")},
+	}}
+
+	assert.Equal(t, "getPetById", captureMCPRequestHeaders(headers).name)
+}
+
+// First wins even when it is empty.
+func TestCaptureMCPRequestHeaders_RepeatedHeaderKeepsFirst(t *testing.T) {
+	t.Parallel()
+
+	headers := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+		{Key: "mcp-method", RawValue: []byte("tools/list")},
+		{Key: "Mcp-Method", RawValue: []byte("tools/call")},
+		{Key: "mcp-name", RawValue: []byte("")},
+		{Key: "mcp-name", RawValue: []byte("getPetById")},
+	}}
+
+	captured := captureMCPRequestHeaders(headers)
+	assert.Equal(t, "tools/list", captured.method)
+	assert.Empty(t, captured.name)
+}
+
+func TestCaptureMCPRequestHeaders_Empty(t *testing.T) {
+	t.Parallel()
+
+	captured := captureMCPRequestHeaders(&corev3.HeaderMap{})
+	assert.Empty(t, captured.protocolVersion)
+	assert.Empty(t, captured.method)
+	assert.Empty(t, captured.name)
+	assert.Empty(t, captured.paramHeaderNames)
+}
+
+func TestDecodeHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		wantOK bool
+	}{
+		{name: "plain value passes through", input: "getPetById", want: "getPetById", wantOK: true},
+		{name: "empty value passes through", input: "", want: "", wantOK: true},
+		{name: "base64 sentinel decodes", input: "=?base64?Z2V0UGV0QnlJZA==?=", want: "getPetById", wantOK: true},
+		{name: "base64 sentinel with non-ascii payload", input: "=?base64?w6l0w6k=?=", want: "été", wantOK: true},
+		{name: "invalid base64 payload fails", input: "=?base64?!!!?=", wantOK: false},
+		{name: "prefix without suffix passes through verbatim", input: "=?base64?abc", want: "=?base64?abc", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := decodeHeaderValue(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/log_test.go
+++ b/log_test.go
@@ -55,7 +55,7 @@ func TestMcpServer_LogsToolCallsToOtel(t *testing.T) {
 
 	// Make a tools/call request
 	toolCallReq := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"listPets","arguments":{}}}`
-	_ = server.mcpRequestHandler(context.Background(), []byte(toolCallReq))
+	_ = server.mcpRequestHandler(context.Background(), []byte(toolCallReq), mcpRequestHeaders{})
 
 	_ = logger.Sync()
 

--- a/mcp.go
+++ b/mcp.go
@@ -61,6 +61,7 @@ type protocolEra interface {
 	// stamping the fields the generation makes mandatory.
 	encodeResult(result any) (json.RawMessage, error)
 	errorStatus(code int64) typev3.StatusCode
+	validateHeaders(req *jsonrpc.Request, metaVersion string, hdrs mcpRequestHeaders) error
 }
 
 // legacyEra serves every revision up to and including [latestLegacyVersion].
@@ -85,6 +86,12 @@ func (legacyEra) encodeResult(result any) (json.RawMessage, error) {
 // protocol errors included, in the body of a successful HTTP response.
 func (legacyEra) errorStatus(int64) typev3.StatusCode {
 	return typev3.StatusCode_OK
+}
+
+// validateHeaders accepts anything. The mirrored MCP request headers are a
+// 2026-07-28 addition, so a legacy client is not required to send them.
+func (legacyEra) validateHeaders(*jsonrpc.Request, string, mcpRequestHeaders) error {
+	return nil
 }
 
 // modernEra serves 2026-07-28 and later. There is no handshake, so the method
@@ -143,7 +150,7 @@ func (e modernEra) metaWithServerInfo(meta map[string]any) map[string]any {
 // as in the legacy era.
 func (modernEra) errorStatus(code int64) typev3.StatusCode {
 	switch code {
-	case mcp.CodeUnsupportedProtocolVersion, jsonrpc.CodeInvalidParams:
+	case mcp.CodeUnsupportedProtocolVersion, mcp.CodeHeaderMismatch, jsonrpc.CodeInvalidParams:
 		return typev3.StatusCode_BadRequest
 	case jsonrpc.CodeMethodNotFound:
 		return typev3.StatusCode_NotFound
@@ -152,16 +159,26 @@ func (modernEra) errorStatus(code int64) typev3.StatusCode {
 	}
 }
 
-// resolveEra also reports whether the request may be served. Past the cutover
-// an unsupported version is refused rather than ignored.
-func (s *extProcServer) resolveEra(method string, declared string) (protocolEra, bool) {
+// validateHeaders enforces SEP-2243 (see [validateModernHeaders]).
+func (modernEra) validateHeaders(req *jsonrpc.Request, metaVersion string, hdrs mcpRequestHeaders) error {
+	return validateModernHeaders(req, metaVersion, hdrs)
+}
+
+// resolveEra also reports the version that selected the era and whether the
+// request may be served. Past the cutover an unsupported version is refused
+// rather than ignored.
+func (s *extProcServer) resolveEra(method string, declared string, mirrored string) (protocolEra, string, bool) {
 	if method == methodInitialize || method == methodNotificationsInitialized {
-		return legacyEra{}, true
+		return legacyEra{}, "", true
 	}
-	if !isModernVersion(declared) {
-		return legacyEra{}, true
+	requested := declared
+	if !isModernVersion(requested) {
+		requested = mirrored
 	}
-	return modernEra{serverInfo: s.serverInfo}, isSupportedVersion(declared)
+	if !isModernVersion(requested) {
+		return legacyEra{}, "", true
+	}
+	return modernEra{serverInfo: s.serverInfo}, requested, isSupportedVersion(requested)
 }
 
 // metaProtocolVersion returns "" when the entry is absent or malformed.

--- a/mcp_handler.go
+++ b/mcp_handler.go
@@ -167,7 +167,7 @@ func toolExecutionErrorResponse(span trace.Span, era protocolEra, id jsonrpc.ID,
 	})
 }
 
-func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte) *mcpProcResponse {
+func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte, hdrs mcpRequestHeaders) *mcpProcResponse {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(attribute.Int(attrBodySize, len(body)))
 
@@ -192,18 +192,20 @@ func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte) *mcp
 	)
 
 	declared := metaProtocolVersion(req.Params)
-	if declared != "" {
-		span.SetAttributes(attribute.String(attrMCPProtocolVersion, protocolVersionLabel(declared)))
+	era, requestedVersion, ok := s.resolveEra(req.Method, declared, hdrs.protocolVersion)
+	if requestedVersion != "" {
+		span.SetAttributes(attribute.String(attrMCPProtocolVersion, protocolVersionLabel(requestedVersion)))
 	}
-
-	era, ok := s.resolveEra(req.Method, declared)
 	if !ok {
 		return errorResponse(span, era, req.ID, mcp.CodeUnsupportedProtocolVersion,
-			fmt.Sprintf("Unsupported protocol version: %s", declared),
-			map[string]any{"supported": supportedProtocolVersions, "requested": declared})
+			fmt.Sprintf("Unsupported protocol version: %s", requestedVersion),
+			map[string]any{"supported": supportedProtocolVersions, "requested": requestedVersion})
 	}
 	if !era.serves(req.Method) {
 		return errorResponse(span, era, req.ID, jsonrpc.CodeMethodNotFound, "Method not found", nil)
+	}
+	if err := era.validateHeaders(req, declared, hdrs); err != nil {
+		return errorResponse(span, era, req.ID, mcp.CodeHeaderMismatch, err.Error(), nil)
 	}
 
 	switch req.Method {
@@ -214,7 +216,7 @@ func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte) *mcp
 	case methodToolsList:
 		return resultResponse(span, era, req.ID, &mcp.ListToolsResult{Tools: s.registry.Tools()})
 	case methodToolsCall:
-		return s.handleToolCall(span, era, req)
+		return s.handleToolCall(span, era, req, hdrs.paramHeaderNames)
 	default:
 		return errorResponse(span, era, req.ID, jsonrpc.CodeMethodNotFound, "Method not found", nil)
 	}
@@ -257,7 +259,7 @@ func (s *extProcServer) handleInitialize(span trace.Span, era protocolEra, req *
 	})
 }
 
-func (s *extProcServer) handleToolCall(span trace.Span, era protocolEra, req *jsonrpc.Request) *mcpProcResponse {
+func (s *extProcServer) handleToolCall(span trace.Span, era protocolEra, req *jsonrpc.Request, stripHeaders []string) *mcpProcResponse {
 	var callParams callToolRequestParams
 	if err := json.Unmarshal(req.Params, &callParams); err != nil {
 		zap.L().Error("Error unmarshaling tool call request", zap.Error(err))
@@ -293,7 +295,7 @@ func (s *extProcServer) handleToolCall(span trace.Span, era protocolEra, req *js
 	)
 	return &mcpProcResponse{
 		Id:                 req.ID,
-		Reroute:            rerouteWithBodyMutation(toolConfig.Endpoint.Host, strings.ToUpper(toolConfig.Endpoint.Method), path, requestBody, endpointReq.extraHeaders),
+		Reroute:            rerouteWithBodyMutation(toolConfig.Endpoint.Host, strings.ToUpper(toolConfig.Endpoint.Method), path, requestBody, endpointReq.extraHeaders, stripHeaders),
 		ToolResponseConfig: &toolConfig.toolResponseConfig,
 		Era:                era,
 	}

--- a/mcp_handler_fuzz_test.go
+++ b/mcp_handler_fuzz_test.go
@@ -66,8 +66,9 @@ func FuzzMcpRequestHandler(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		ctx := context.Background()
-		// Must not panic regardless of input
-		server.mcpRequestHandler(ctx, data)
+		// Must not panic regardless of input, with and without modern headers
+		server.mcpRequestHandler(ctx, data, mcpRequestHeaders{})
+		server.mcpRequestHandler(ctx, data, mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall, name: "getPetById"})
 	})
 }
 

--- a/mcp_handler_jsonrpc_errors_test.go
+++ b/mcp_handler_jsonrpc_errors_test.go
@@ -73,7 +73,7 @@ func TestMcpRequestHandler_JSONRPCErrorCodes(t *testing.T) {
 			t.Parallel()
 			server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
-			result := server.mcpRequestHandler(context.Background(), tt.requestBody)
+			result := server.mcpRequestHandler(context.Background(), tt.requestBody, mcpRequestHeaders{})
 
 			require.NotNil(t, result)
 			require.NotNil(t, result.Immediate)

--- a/mcp_handler_modern_test.go
+++ b/mcp_handler_modern_test.go
@@ -22,8 +22,9 @@ func TestModernRequests_HappyPaths(t *testing.T) {
 		server.serverInfo = ServerInfo{Name: "test-server", Version: "1.2.3"}
 
 		requestBody := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{` + modernMeta + `}}`)
+		headers := mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsList}
 
-		response := server.mcpRequestHandler(context.Background(), requestBody)
+		response := server.mcpRequestHandler(context.Background(), requestBody, headers)
 		immediate := requireImmediateResponse(t, response.Immediate)
 		assert.Equal(t, typev3.StatusCode_OK, immediate.GetStatus().GetCode())
 
@@ -36,24 +37,13 @@ func TestModernRequests_HappyPaths(t *testing.T) {
 		require.NotEmpty(t, tools)
 	})
 
-	t.Run("tools/call reroutes and records the resolved era", func(t *testing.T) {
-		t.Parallel()
-		server := newTestServer(t, "testdata/petstore.openapi.yaml")
-
-		requestBody := []byte(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},` + modernMeta + `}}`)
-
-		response := server.mcpRequestHandler(context.Background(), requestBody)
-		require.NotNil(t, response.Reroute, "modern tools/call should reroute upstream")
-		assert.IsType(t, modernEra{}, response.Era)
-	})
-
 	t.Run("initialize never negotiates a modern version", func(t *testing.T) {
 		t.Parallel()
 		server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
 		requestBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},` + modernMeta + `}}`)
 
-		response := server.mcpRequestHandler(context.Background(), requestBody)
+		response := server.mcpRequestHandler(context.Background(), requestBody, mcpRequestHeaders{})
 		immediate := requireImmediateResponse(t, response.Immediate)
 
 		_, result := decodeJSONRPCResult(t, immediate.GetBody())
@@ -65,23 +55,95 @@ func TestModernRequests_HappyPaths(t *testing.T) {
 func TestModernRequests_ErrorPaths(t *testing.T) {
 	t.Parallel()
 
+	toolsCallBody := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},` + modernMeta + `}}`
+
 	tests := []struct {
 		name           string
 		requestBody    string
+		headers        mcpRequestHeaders
 		wantHTTPStatus typev3.StatusCode
 		wantCode       int64
 		wantMessage    string
 	}{
 		{
+			name:           "missing MCP-Protocol-Version header",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta + `}}`,
+			headers:        mcpRequestHeaders{method: methodToolsList},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+			wantMessage:    "missing required MCP-Protocol-Version header",
+		},
+		{
+			name:           "modern header without body _meta",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsList},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+		},
+		{
+			name:           "protocol version mismatch",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta + `}}`,
+			headers:        mcpRequestHeaders{protocolVersion: "2027-01-01", method: methodToolsList},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+		},
+		{
+			name:           "missing Mcp-Method header",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta + `}}`,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+			wantMessage:    "missing required Mcp-Method header",
+		},
+		{
+			name:           "Mcp-Method mismatch",
+			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta + `}}`,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+		},
+		{
+			name:           "missing Mcp-Name header for tools/call",
+			requestBody:    toolsCallBody,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+		},
+		{
+			name:           "Mcp-Name mismatch",
+			requestBody:    toolsCallBody,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall, name: "otherTool"},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+		},
+		{
+			name:        "Mcp-Name mismatch reports the decoded value",
+			requestBody: toolsCallBody,
+			// "otherTool" wrapped in the =?base64?...?= sentinel
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall, name: "=?base64?b3RoZXJUb29s?="},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+			wantMessage:    "header mismatch: Mcp-Name header value 'otherTool' does not match body value 'getPetById'",
+		},
+		{
+			name:           "Mcp-Name invalid Base64 sentinel",
+			requestBody:    toolsCallBody,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall, name: "=?base64?!!!?="},
+			wantHTTPStatus: typev3.StatusCode_BadRequest,
+			wantCode:       mcp.CodeHeaderMismatch,
+		},
+		{
 			name:           "unknown method gets 404",
 			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{` + modernMeta + `}}`,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: "resources/list"},
 			wantHTTPStatus: typev3.StatusCode_NotFound,
-			wantCode:       jsonrpc.CodeMethodNotFound,
+			wantCode:       -32601,
 			wantMessage:    "Method not found",
 		},
 		{
 			name:           "unknown tool gets 400",
 			requestBody:    `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"noSuchTool","arguments":{},` + modernMeta + `}}`,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsCall, name: "noSuchTool"},
 			wantHTTPStatus: typev3.StatusCode_BadRequest,
 			wantCode:       jsonrpc.CodeInvalidParams,
 			wantMessage:    "Unknown tool: noSuchTool",
@@ -93,7 +155,7 @@ func TestModernRequests_ErrorPaths(t *testing.T) {
 			t.Parallel()
 			server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
-			response := server.mcpRequestHandler(context.Background(), []byte(tt.requestBody))
+			response := server.mcpRequestHandler(context.Background(), []byte(tt.requestBody), tt.headers)
 			require.NotNil(t, response)
 			immediate := requireImmediateResponse(t, response.Immediate)
 			assert.Equal(t, tt.wantHTTPStatus, immediate.GetStatus().GetCode(), "HTTP status")
@@ -106,16 +168,19 @@ func TestModernRequests_ErrorPaths(t *testing.T) {
 	}
 }
 
+// The legacy era imposes no mirrored-header contract, so the declaration is
+// ignored, headers included.
 func TestModernRequests_PreCutoverMetaVersionIsIgnored(t *testing.T) {
 	t.Parallel()
 
 	legacyMeta := `"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}`
+	legacyHeaders := mcpRequestHeaders{protocolVersion: v20251125}
 
 	t.Run("tools/list is served unshaped", func(t *testing.T) {
 		t.Parallel()
 		server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
-		response := server.mcpRequestHandler(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{`+legacyMeta+`}}`))
+		response := server.mcpRequestHandler(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{`+legacyMeta+`}}`), legacyHeaders)
 		immediate := requireImmediateResponse(t, response.Immediate)
 		assert.Equal(t, typev3.StatusCode_OK, immediate.GetStatus().GetCode())
 
@@ -128,7 +193,7 @@ func TestModernRequests_PreCutoverMetaVersionIsIgnored(t *testing.T) {
 		t.Parallel()
 		server := newTestServer(t, "testdata/petstore.openapi.yaml")
 
-		response := server.mcpRequestHandler(context.Background(), []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},`+legacyMeta+`}}`))
+		response := server.mcpRequestHandler(context.Background(), []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},`+legacyMeta+`}}`), legacyHeaders)
 		require.NotNil(t, response.Reroute)
 		assert.IsType(t, legacyEra{}, response.Era)
 	})
@@ -139,8 +204,9 @@ func TestModernRequests_UnsupportedVersion(t *testing.T) {
 
 	server := newTestServer(t, "testdata/petstore.openapi.yaml")
 	requestBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}`)
+	headers := mcpRequestHeaders{protocolVersion: "2099-01-01", method: methodToolsList}
 
-	response := server.mcpRequestHandler(context.Background(), requestBody)
+	response := server.mcpRequestHandler(context.Background(), requestBody, headers)
 	immediate := requireImmediateResponse(t, response.Immediate)
 	assert.Equal(t, typev3.StatusCode_BadRequest, immediate.GetStatus().GetCode(), "HTTP status")
 
@@ -195,4 +261,27 @@ func TestToolCallResponseShapingPerEra(t *testing.T) {
 			require.NotEmpty(t, content)
 		})
 	}
+}
+
+func TestModernToolCallStripsMCPHeadersOnReroute(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, "testdata/petstore.openapi.yaml")
+	requestBody := []byte(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":1},` + modernMeta + `}}`)
+	headers := mcpRequestHeaders{
+		protocolVersion:  v20260728,
+		method:           methodToolsCall,
+		name:             "getPetById",
+		paramHeaderNames: []string{"mcp-param-x-trace"},
+	}
+
+	response := server.mcpRequestHandler(context.Background(), requestBody, headers)
+	require.NotNil(t, response.Reroute, "modern tools/call should reroute upstream")
+	assert.IsType(t, modernEra{}, response.Era)
+
+	removed := response.Reroute.headers.GetRequestHeaders().GetResponse().GetHeaderMutation().GetRemoveHeaders()
+	assert.Contains(t, removed, headerMCPProtocolVersion)
+	assert.Contains(t, removed, headerMCPMethod)
+	assert.Contains(t, removed, headerMCPName)
+	assert.Contains(t, removed, "mcp-param-x-trace")
 }

--- a/mcp_handler_protocol_translation_test.go
+++ b/mcp_handler_protocol_translation_test.go
@@ -285,7 +285,7 @@ func TestPetstoreProtocolTranslation_OperationCases(t *testing.T) {
 			assertToolTranslation(t, tool, toolConfig, tc.toolExpectation)
 
 			requestBody := buildToolsCallRequest(t, tc.operationID, tc.requestArguments)
-			reqResult := server.mcpRequestHandler(context.Background(), requestBody)
+			reqResult := server.mcpRequestHandler(context.Background(), requestBody, mcpRequestHeaders{})
 			require.NotNil(t, reqResult)
 			require.NotNil(t, reqResult.Reroute)
 			assertRequestTranslation(t, reqResult, tc.requestExpectation)
@@ -346,7 +346,7 @@ func TestPetstoreProtocolTranslation_ToolExecutionErrorPaths(t *testing.T) {
 				tc.setup(t, registry)
 			}
 
-			result := server.mcpRequestHandler(context.Background(), tc.request)
+			result := server.mcpRequestHandler(context.Background(), tc.request, mcpRequestHeaders{})
 			require.NotNil(t, result)
 			require.NotNil(t, result.Immediate)
 

--- a/mcp_handler_tracing_test.go
+++ b/mcp_handler_tracing_test.go
@@ -19,6 +19,7 @@ func TestMcpRequestHandler_Tracing(t *testing.T) {
 	tests := []struct {
 		name                  string
 		requestBody           string
+		headers               mcpRequestHeaders
 		wantNilResp           bool
 		wantMethod            string
 		wantMCPMethod         string
@@ -104,7 +105,7 @@ func TestMcpRequestHandler_Tracing(t *testing.T) {
 			ctx, rootSpan := tracer.Start(context.Background(), spanName)
 
 			// Call the handler
-			resp := server.mcpRequestHandler(ctx, []byte(tt.requestBody))
+			resp := server.mcpRequestHandler(ctx, []byte(tt.requestBody), tt.headers)
 			assert.True(t, tt.wantNilResp == (resp == nil), "mcpRequestHandler() nil return")
 
 			rootSpan.End()
@@ -164,8 +165,9 @@ func TestMcpRequestHandler_ProtocolVersionAttributeIsBounded(t *testing.T) {
 			ctx, rootSpan := tracer.Start(context.Background(), spanName)
 
 			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":%q}}}`, tt.declared)
+			hdrs := mcpRequestHeaders{protocolVersion: tt.declared, method: methodToolsList}
 
-			server.mcpRequestHandler(ctx, []byte(body))
+			server.mcpRequestHandler(ctx, []byte(body), hdrs)
 			rootSpan.End()
 
 			testSpan, found := findSpanByName(spanRecorder.Ended(), spanName)

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -53,30 +53,42 @@ func TestResolveEra(t *testing.T) {
 	server := &extProcServer{serverInfo: ServerInfo{Name: "srv", Version: "1"}}
 
 	tests := []struct {
-		name     string
-		method   string
-		declared string
-		wantEra  protocolEra
-		wantOK   bool
+		name        string
+		method      string
+		declared    string
+		mirrored    string
+		wantEra     protocolEra
+		wantVersion string
+		wantOK      bool
 	}{
-		{name: "no declared version is legacy", method: methodToolsList, wantEra: legacyEra{}, wantOK: true},
+		{name: "nothing declared is legacy", method: methodToolsList, wantEra: legacyEra{}, wantOK: true},
 		{name: "initialize is legacy", method: methodInitialize, wantEra: legacyEra{}, wantOK: true},
 		{name: "initialize ignores a declared version", method: methodInitialize, declared: v20260728, wantEra: legacyEra{}, wantOK: true},
 		{name: "notifications/initialized is legacy", method: methodNotificationsInitialized, declared: v20260728, wantEra: legacyEra{}, wantOK: true},
-		{name: "supported modern version", method: methodToolsList, declared: v20260728, wantEra: modernEra{}, wantOK: true},
+		{name: "supported modern _meta version", method: methodToolsList, declared: v20260728, wantEra: modernEra{}, wantVersion: v20260728, wantOK: true},
 		// A pre-cutover declaration is a legacy client restating its negotiated
 		// version, so it is ignored and the request is served.
-		{name: "pre-cutover version is ignored", method: methodToolsList, declared: v20251125, wantEra: legacyEra{}, wantOK: true},
-		{name: "unsupported older version is ignored", method: methodToolsList, declared: "2024-11-05", wantEra: legacyEra{}, wantOK: true},
+		{name: "pre-cutover _meta version is ignored", method: methodToolsList, declared: v20251125, wantEra: legacyEra{}, wantOK: true},
+		{name: "unsupported older _meta version is ignored", method: methodToolsList, declared: "2024-11-05", wantEra: legacyEra{}, wantOK: true},
 		// Past the cutover the declaration is binding, so an unknown version
 		// there is refused rather than ignored.
-		{name: "unknown future version is refused", method: methodToolsList, declared: "2099-01-01", wantEra: modernEra{}, wantOK: false},
+		{name: "unknown future _meta version is refused", method: methodToolsList, declared: "2099-01-01", wantEra: modernEra{}, wantVersion: "2099-01-01"},
+		// The mirrored MCP-Protocol-Version header selects the era on its own,
+		// so a client that sends it but omits _meta is handled as modern and
+		// fails header validation instead of falling back to legacy.
+		{name: "mirrored modern header alone selects modern", method: methodToolsList, mirrored: v20260728, wantEra: modernEra{}, wantVersion: v20260728, wantOK: true},
+		{name: "mirrored legacy header stays legacy", method: methodToolsList, mirrored: v20251125, wantEra: legacyEra{}, wantOK: true},
+		// A pre-cutover _meta entry alongside a modern header is modern
+		// (via the header) and then fails header validation, not version checks.
+		{name: "pre-cutover _meta with modern header", method: methodToolsList, declared: v20251125, mirrored: v20260728, wantEra: modernEra{}, wantVersion: v20260728, wantOK: true},
+		{name: "_meta wins over a mirrored header", method: methodToolsList, declared: v20260728, mirrored: "2099-01-01", wantEra: modernEra{}, wantVersion: v20260728, wantOK: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			era, ok := server.resolveEra(tt.method, tt.declared)
+			era, version, ok := server.resolveEra(tt.method, tt.declared, tt.mirrored)
 			assert.IsType(t, tt.wantEra, era)
+			assert.Equal(t, tt.wantVersion, version)
 			assert.Equal(t, tt.wantOK, ok)
 		})
 	}
@@ -124,6 +136,19 @@ func TestProtocolEraErrorStatus(t *testing.T) {
 			assert.Equal(t, tt.wantModern, modernEra{}.errorStatus(tt.code), "modern")
 		})
 	}
+}
+
+func TestProtocolEraValidateHeaders(t *testing.T) {
+	req := &jsonrpc.Request{Method: methodToolsList}
+
+	mirrored := mcpRequestHeaders{protocolVersion: v20260728, method: methodToolsList}
+	bare := mcpRequestHeaders{}
+
+	assert.NoError(t, legacyEra{}.validateHeaders(req, "", bare), "legacy tolerates absent headers")
+	assert.NoError(t, legacyEra{}.validateHeaders(req, "", mirrored), "legacy tolerates present headers")
+
+	assert.NoError(t, modernEra{}.validateHeaders(req, v20260728, mirrored))
+	assert.Error(t, modernEra{}.validateHeaders(req, v20260728, bare), "the modern era requires the mirrored headers")
 }
 
 func TestProtocolEraEncodeResult(t *testing.T) {

--- a/stream_state.go
+++ b/stream_state.go
@@ -115,7 +115,7 @@ func (st *stateAwaitingRequestHeaders) handle(ctx context.Context, strm *stream,
 			return &stateAwaitingRequestHeaders{}, newImmediateBodyResponse(encodeJSONRPCError(jsonrpc.ID{}, jsonrpc.CodeInvalidRequest, msg)), nil
 		}
 		strm.beginBuffering()
-		return &stateBufferingRequest{}, nil, nil
+		return &stateBufferingRequest{mcpHeaders: captureMCPRequestHeaders(hdr.RequestHeaders.GetHeaders())}, nil, nil
 	}
 
 	return protocolViolation(req, "RequestHeaders")
@@ -146,7 +146,11 @@ func (st *stateDrainingRequest) handle(ctx context.Context, strm *stream, req *e
 }
 
 // stateBufferingRequest receives RequestBody chunks until EndOfStream.
-type stateBufferingRequest struct{}
+type stateBufferingRequest struct {
+	// mcpHeaders are the MCP Streamable HTTP headers captured at the
+	// request-headers phase, validated against the body once it is buffered.
+	mcpHeaders mcpRequestHeaders
+}
 
 func (st *stateBufferingRequest) handle(ctx context.Context, strm *stream, req *extProcPb.ProcessingRequest) (streamState, []*extProcPb.ProcessingResponse, error) {
 	switch value := req.Request.(type) {
@@ -173,7 +177,7 @@ func (st *stateBufferingRequest) finalize(ctx context.Context, strm *stream, has
 	)
 	defer span.End()
 
-	handlerResult := strm.server.mcpRequestHandler(ctx, strm.buf)
+	handlerResult := strm.server.mcpRequestHandler(ctx, strm.buf, st.mcpHeaders)
 
 	reqCtx := requestContext{
 		jsonrpcID:          handlerResult.Id,


### PR DESCRIPTION
SEP-2243 requires Streamable HTTP POSTs to carry standard MCP request
headers: Mcp-Method, and Mcp-Name for tools/call alongside
MCP-Protocol-Version, so intermediaries can route and authorize a
request without parsing its JSON-RPC body (changelog Minor 4).

Headers that intermediaries act on are only useful if they are
trustworthy, so a modern request whose headers disagree with its body is
refused with HTTP 400 and HeaderMismatch (-32020). Mcp-Name accepts the
=?base64?...?= sentinel wrapper for tool names outside the header
charset. A modern MCP-Protocol-Version header now also selects the
modern era on its own, so a client that mirrors correctly but omits the
_meta entry gets a header-mismatch error rather than silently falling
back to legacy handling.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>