### PR TITLE
Stamp ttlMs/cacheScope cache hints on modern list results

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ disjoint entry points, so every request selects one unambiguously:
   and mismatches are refused with HTTP 400 and JSON-RPC error `-32020`. Results carry `resultType` and the
   serverInfo `_meta` entry, and an unknown method answers HTTP 404 rather than the legacy 200.
 
+### Tool list caching
+
+Modern `tools/list` results carry fixed cache hints: `ttlMs: 300000` (five minutes) and `cacheScope: "private"`.
+The tool list changes only on redeploy, and an `ext_proc` filter cannot push `notifications/tools/list_changed`,
+so the TTL is what brings a client back. Five minutes bounds how long a client may keep using a retired list.
+Re-fetching is cheap, since the list is served from memory and never reaches the upstream API.
+
 ## OpenTelemetry
 
 To enable export of logs and traces to an OpenTelemetry collector, use one of the options below. If neither is used, the server runs with a no-op tracer provider and a no-op logger.

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -132,6 +132,9 @@ case_tools_list() {
   local name="tools/list -> non-empty tool list"
   post "$name" 200 '{"jsonrpc":"2.0","id":3,"method":"tools/list"}' || return 0
   assert_jq "$name" '.id == 3 and (.result.tools | length > 0)' || return 0
+  # cache hints are a 2026-07-28 field: pre-2026 clients must not see them.
+  assert_jq "$name" '.result | has("ttlMs") | not' || return 0
+  assert_jq "$name" '.result | has("cacheScope") | not' || return 0
   pass "$name"
 }
 
@@ -185,6 +188,8 @@ case_modern_tools_list() {
   post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/list\",\"params\":{$MODERN_META}}" \
     -H 'MCP-Protocol-Version: 2026-07-28' -H 'Mcp-Method: tools/list' || return 0
   assert_jq "$name" '.id == 21 and .result.resultType == "complete" and (.result.tools | length > 0)' || return 0
+  # the example server configures neither hint, so these are the defaults.
+  assert_jq "$name" '.result.ttlMs == 300000 and .result.cacheScope == "private"' || return 0
   assert_jq "$name" '.result._meta["io.modelcontextprotocol/serverInfo"] != null' || return 0
   pass "$name"
 }

--- a/mcp.go
+++ b/mcp.go
@@ -78,6 +78,8 @@ func (legacyEra) serves(method string) bool {
 	}
 }
 
+// encodeResult marshals the result as-is: every modern envelope field encodes as
+// absent when unset (see [resultMeta] and [listToolsResult]).
 func (legacyEra) encodeResult(result any) (json.RawMessage, error) {
 	return json.Marshal(result)
 }
@@ -101,6 +103,16 @@ type modernEra struct {
 	serverInfo ServerInfo
 }
 
+// Cache hints for the results the revision makes cacheable (changelog Minor 5).
+// Both are fixed. Five minutes bounds how long a client may keep using a
+// previous deployment's tool list, since a redeploy is the only way it changes
+// and an ext_proc filter has no channel to announce one. "private" keeps the
+// response out of shared caches it never travels through anyway.
+const (
+	listCacheTTLMillis = 300000
+	listCacheScope     = "private"
+)
+
 func (modernEra) serves(method string) bool {
 	switch method {
 	case methodToolsList, methodToolsCall:
@@ -110,27 +122,34 @@ func (modernEra) serves(method string) bool {
 	}
 }
 
-// encodeResult stamps the 2026-07-28 envelope fields — the required resultType
-// and the serverInfo _meta entry servers SHOULD add — onto the results the
-// methods in [modernEra.serves] produce, and refuses anything else.
+// encodeResult stamps the 2026-07-28 envelope fields onto the results the
+// methods in [modernEra.serves] produce: the required resultType, the serverInfo
+// _meta entry servers SHOULD add, and the cache hints on cacheable results.
 func (e modernEra) encodeResult(result any) (json.RawMessage, error) {
 	switch r := result.(type) {
 	case *callToolResult:
 		if r == nil {
 			break
 		}
-		r.Meta = e.metaWithServerInfo(r.Meta)
-		r.ResultType = resultTypeComplete
+		e.stampEnvelope(&r.resultMeta)
 		return json.Marshal(r)
-	case *mcp.ListToolsResult:
+	case *listToolsResult:
 		if r == nil {
 			break
 		}
-		r.SetMeta(e.metaWithServerInfo(r.GetMeta()))
-		r.ResultType = resultTypeComplete
+		e.stampEnvelope(&r.resultMeta)
+		// SEP-2549 makes a tool list cacheable; a tool call's result is not.
+		r.Cacheable = &mcp.Cacheable{TTLMs: listCacheTTLMillis, CacheScope: listCacheScope}
 		return json.Marshal(r)
 	}
 	return nil, fmt.Errorf("modern era cannot encode result %T", result)
+}
+
+// stampEnvelope writes the fields every modern result carries: the serverInfo
+// _meta entry (SEP-2575) and resultType (SEP-2322).
+func (e modernEra) stampEnvelope(m *resultMeta) {
+	m.Meta = e.metaWithServerInfo(m.Meta)
+	m.ResultType = resultTypeComplete
 }
 
 // metaWithServerInfo adds the serverInfo entry (SEP-2575), leaving the rest.

--- a/mcp_handler.go
+++ b/mcp_handler.go
@@ -214,7 +214,7 @@ func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte, hdrs
 	case methodNotificationsInitialized:
 		return &mcpProcResponse{Id: req.ID, Immediate: httpStatusResponse(typev3.StatusCode_Accepted)}
 	case methodToolsList:
-		return resultResponse(span, era, req.ID, &mcp.ListToolsResult{Tools: s.registry.Tools()})
+		return resultResponse(span, era, req.ID, &listToolsResult{Tools: s.registry.Tools()})
 	case methodToolsCall:
 		return s.handleToolCall(span, era, req, hdrs.paramHeaderNames)
 	default:

--- a/mcp_handler_modern_test.go
+++ b/mcp_handler_modern_test.go
@@ -30,6 +30,8 @@ func TestModernRequests_HappyPaths(t *testing.T) {
 
 		_, result := decodeJSONRPCResult(t, immediate.GetBody())
 		assert.Equal(t, "complete", result["resultType"], "resultType")
+		assert.Equal(t, float64(listCacheTTLMillis), result["ttlMs"], "ttlMs")
+		assert.Equal(t, listCacheScope, result["cacheScope"], "cacheScope")
 		assertServerInfoMeta(t, result, "test-server", "1.2.3")
 
 		tools, ok := result["tools"].([]any)
@@ -187,6 +189,8 @@ func TestModernRequests_PreCutoverMetaVersionIsIgnored(t *testing.T) {
 		_, result := decodeJSONRPCResult(t, immediate.GetBody())
 		assert.NotContains(t, result, "resultType", "an ignored declaration must not shape the result")
 		assert.NotContains(t, result, "_meta")
+		assert.NotContains(t, result, "ttlMs", "legacy result should not carry cache hints")
+		assert.NotContains(t, result, "cacheScope", "legacy result should not carry cache hints")
 	})
 
 	t.Run("tools/call reroutes on the legacy era", func(t *testing.T) {

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -157,12 +157,13 @@ func TestProtocolEraEncodeResult(t *testing.T) {
 	tests := []struct {
 		name      string
 		newResult func() any
+		cacheable bool
 	}{
 		{name: "tools/call", newResult: func() any {
 			return &callToolResult{Content: newTextContent("hi")}
 		}},
-		{name: "tools/list", newResult: func() any {
-			return &mcp.ListToolsResult{Tools: []*mcp.Tool{{Name: "tool"}}}
+		{name: "tools/list", cacheable: true, newResult: func() any {
+			return &listToolsResult{Tools: []*mcp.Tool{{Name: "tool"}}}
 		}},
 	}
 
@@ -174,6 +175,10 @@ func TestProtocolEraEncodeResult(t *testing.T) {
 			require.NoError(t, json.Unmarshal(legacyJSON, &legacyObj))
 			assert.NotContains(t, legacyObj, "resultType")
 			assert.NotContains(t, legacyObj, "_meta")
+			// The hints postdate this era, and a zero ttlMs would mean
+			// "immediately stale" rather than "no hint given".
+			assert.NotContains(t, legacyObj, "ttlMs")
+			assert.NotContains(t, legacyObj, "cacheScope")
 
 			era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
 			modernJSON, err := era.encodeResult(tt.newResult())
@@ -182,6 +187,14 @@ func TestProtocolEraEncodeResult(t *testing.T) {
 			require.NoError(t, json.Unmarshal(modernJSON, &modernObj))
 			assert.Equal(t, "complete", modernObj["resultType"])
 			assertServerInfoMeta(t, modernObj, "srv", "1.2.3")
+
+			if tt.cacheable {
+				assert.Equal(t, float64(listCacheTTLMillis), modernObj["ttlMs"])
+				assert.Equal(t, listCacheScope, modernObj["cacheScope"])
+			} else {
+				assert.NotContains(t, modernObj, "ttlMs")
+				assert.NotContains(t, modernObj, "cacheScope")
+			}
 		})
 	}
 }
@@ -217,7 +230,7 @@ func TestModernEraEncodeResultRefusesUnstampable(t *testing.T) {
 	}{
 		{name: "untyped nil", result: nil},
 		{name: "nil tools/call result", result: (*callToolResult)(nil)},
-		{name: "nil tools/list result", result: (*mcp.ListToolsResult)(nil)},
+		{name: "nil tools/list result", result: (*listToolsResult)(nil)},
 		// initialize is legacy-only, so its result never reaches this era.
 		{name: "result of a method the era does not serve", result: &mcp.InitializeResult{}},
 	}
@@ -252,6 +265,23 @@ func TestCallToolResultDecodesAsSDKResult(t *testing.T) {
 	assert.True(t, decoded.IsError)
 	// Decoded through any, so the count arrives as a float64.
 	assert.Equal(t, map[string]any{"count": float64(42)}, decoded.StructuredContent)
+	assertServerInfoMeta(t, map[string]any{"_meta": map[string]any(decoded.GetMeta())}, "srv", "1.2.3")
+}
+
+// TestListToolsResultDecodesAsSDKResult is the tools/list counterpart of
+// [TestCallToolResultDecodesAsSDKResult], cache hints included.
+func TestListToolsResultDecodesAsSDKResult(t *testing.T) {
+	era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
+	encoded, err := era.encodeResult(&listToolsResult{Tools: []*mcp.Tool{{Name: "tool"}}})
+	require.NoError(t, err)
+
+	var decoded mcp.ListToolsResult
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+	require.Len(t, decoded.Tools, 1)
+	assert.Equal(t, "tool", decoded.Tools[0].Name)
+	assert.Equal(t, listCacheTTLMillis, decoded.GetTTLMs())
+	assert.Equal(t, listCacheScope, decoded.GetCacheScope())
 	assertServerInfoMeta(t, map[string]any{"_meta": map[string]any(decoded.GetMeta())}, "srv", "1.2.3")
 }
 

--- a/result.go
+++ b/result.go
@@ -1,10 +1,13 @@
 package envoy_mcp_openapi_processor
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
 
 // resultTypeComplete is the only result type this server produces. It answers
-// from the upstream API and never asks the client for further input. Untyped so
-// it assigns to go-sdk's unexported resultType on [mcp.ListToolsResult] too.
+// from the upstream API and never asks the client for further input.
 const resultTypeComplete = "complete"
 
 // resultMeta holds the envelope fields the 2026-07-28 revision defines on every
@@ -25,6 +28,15 @@ type callToolResult struct {
 	// the tool declares an output schema.
 	StructuredContent json.RawMessage `json:"structuredContent,omitempty"`
 	IsError           bool            `json:"isError,omitempty"`
+}
+
+// listToolsResult mirrors [mcp.ListToolsResult] because the sdk
+// embeds [mcp.Cacheable] without omitempty and cannot express "no cache hints"
+// which we need to omit when responding to pre-2026 clients.
+type listToolsResult struct {
+	resultMeta
+	*mcp.Cacheable
+	Tools []*mcp.Tool `json:"tools"`
 }
 
 // textContent is the only content kind this server emits. Every tool result is


### PR DESCRIPTION
SEP-2549 requires results from tools/list to carry ttlMs and cacheScope
via the CacheableResult interface: ttlMs is a freshness hint letting
clients cache the list and stop polling, and cacheScope says whether
shared intermediaries may cache it too (changelog Minor 5).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>