### PR TITLE
Implement the mandatory server/discover RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,20 @@ disjoint entry points, so every request selects one unambiguously:
 - **Legacy era (`2025-06-18`, `2025-11-25`)**: the client starts with the `initialize` handshake and declares no
   version on subsequent requests. Version negotiation never yields a modern version, so a client that asks for
   one over the handshake is answered with a version it can actually use statefully.
-- **Modern era (`2026-07-28`)**: there is no handshake. Every request carries its protocol version in
-  `params._meta` (`io.modelcontextprotocol/protocolVersion`) and mirrors it in the `MCP-Protocol-Version` header,
-  alongside `Mcp-Method` (and `Mcp-Name` for `tools/call`). Those headers are validated against the JSON-RPC body
-  and mismatches are refused with HTTP 400 and JSON-RPC error `-32020`. Results carry `resultType` and the
+- **Modern era (`2026-07-28`)**: there is no handshake. The mandatory `server/discover` RPC replaces
+  `initialize`, and every request carries its protocol version in `params._meta`
+  (`io.modelcontextprotocol/protocolVersion`) and mirrors it in the `MCP-Protocol-Version` header, alongside
+  `Mcp-Method` (and `Mcp-Name` for `tools/call`). Those headers are validated against the JSON-RPC body and
+  mismatches are refused with HTTP 400 and JSON-RPC error `-32020`. Results carry `resultType` and the
   serverInfo `_meta` entry, and an unknown method answers HTTP 404 rather than the legacy 200.
 
-### Tool list caching
+### Result caching
 
-Modern `tools/list` results carry fixed cache hints: `ttlMs: 300000` (five minutes) and `cacheScope: "private"`.
-The tool list changes only on redeploy, and an `ext_proc` filter cannot push `notifications/tools/list_changed`,
-so the TTL is what brings a client back. Five minutes bounds how long a client may keep using a retired list.
-Re-fetching is cheap, since the list is served from memory and never reaches the upstream API.
+Modern `server/discover` and `tools/list` results carry fixed cache hints: `ttlMs: 300000` (five minutes) and
+`cacheScope: "private"`. The tool list changes only on redeploy, and an `ext_proc` filter cannot push
+`notifications/tools/list_changed`, so the TTL is what brings a client back. Five minutes bounds how long a
+client may keep using a retired list. Re-fetching is cheap, since both results are served from memory and never
+reach the upstream API.
 
 ## OpenTelemetry
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -183,6 +183,18 @@ case_malformed_json() {
 
 MODERN_META='"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}'
 
+# server/discover is the modern replacement for the initialize handshake.
+case_modern_discover() {
+  local name="modern server/discover -> complete result with cache hints"
+  post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":20,\"method\":\"server/discover\",\"params\":{$MODERN_META}}" \
+    -H 'MCP-Protocol-Version: 2026-07-28' -H 'Mcp-Method: server/discover' || return 0
+  assert_jq "$name" '.id == 20 and .result.resultType == "complete"' || return 0
+  assert_jq "$name" '.result.supportedVersions[0] == "2026-07-28"' || return 0
+  assert_jq "$name" '.result.ttlMs == 300000 and .result.cacheScope == "private"' || return 0
+  assert_jq "$name" '.result.capabilities.tools != null' || return 0
+  pass "$name"
+}
+
 case_modern_tools_list() {
   local name="modern tools/list -> shaped result"
   post "$name" 200 "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/list\",\"params\":{$MODERN_META}}" \
@@ -389,6 +401,7 @@ case_empty_upstream_body
 case_rebinding_origin
 case_allowed_origin
 case_malformed_json
+case_modern_discover
 case_modern_tools_list
 case_modern_tool_call
 case_modern_unsupported_version

--- a/mcp.go
+++ b/mcp.go
@@ -103,19 +103,19 @@ type modernEra struct {
 	serverInfo ServerInfo
 }
 
-// Cache hints for the results the revision makes cacheable (changelog Minor 5).
-// Both are fixed. Five minutes bounds how long a client may keep using a
-// previous deployment's tool list, since a redeploy is the only way it changes
-// and an ext_proc filter has no channel to announce one. "private" keeps the
-// response out of shared caches it never travels through anyway.
+// Cache hints for the results the revision makes cacheable (changelog Minor 5),
+// server/discover and tools/list. Both are fixed. Five minutes bounds how long a
+// client may keep using a previous deployment's answers, since a redeploy is the
+// only way they change and an ext_proc filter has no channel to announce one.
+// "private" keeps them out of shared caches they never travel through anyway.
 const (
-	listCacheTTLMillis = 300000
-	listCacheScope     = "private"
+	cacheTTLMillis = 300000
+	cacheScope     = "private"
 )
 
 func (modernEra) serves(method string) bool {
 	switch method {
-	case methodToolsList, methodToolsCall:
+	case methodDiscover, methodToolsList, methodToolsCall:
 		return true
 	default:
 		return false
@@ -139,7 +139,17 @@ func (e modernEra) encodeResult(result any) (json.RawMessage, error) {
 		}
 		e.stampEnvelope(&r.resultMeta)
 		// SEP-2549 makes a tool list cacheable; a tool call's result is not.
-		r.Cacheable = &mcp.Cacheable{TTLMs: listCacheTTLMillis, CacheScope: listCacheScope}
+		r.Cacheable = &mcp.Cacheable{TTLMs: cacheTTLMillis, CacheScope: cacheScope}
+		return json.Marshal(r)
+	case *mcp.DiscoverResult:
+		// Keeps the sdk's type. No legacy client reaches server/discover, so the
+		// fields the sdk always marshals are the ones we want.
+		if r == nil {
+			break
+		}
+		r.SetMeta(e.metaWithServerInfo(r.GetMeta()))
+		r.ResultType = resultTypeComplete
+		r.Cacheable = mcp.Cacheable{TTLMs: cacheTTLMillis, CacheScope: cacheScope}
 		return json.Marshal(r)
 	}
 	return nil, fmt.Errorf("modern era cannot encode result %T", result)

--- a/mcp_handler.go
+++ b/mcp_handler.go
@@ -54,6 +54,7 @@ const (
 	methodToolsList                = "tools/list"
 	methodToolsCall                = "tools/call"
 	methodNotificationsInitialized = "notifications/initialized"
+	methodDiscover                 = "server/discover"
 )
 
 type mcpProcResponse struct {
@@ -213,6 +214,8 @@ func (s *extProcServer) mcpRequestHandler(ctx context.Context, body []byte, hdrs
 		return s.handleInitialize(span, era, req)
 	case methodNotificationsInitialized:
 		return &mcpProcResponse{Id: req.ID, Immediate: httpStatusResponse(typev3.StatusCode_Accepted)}
+	case methodDiscover:
+		return s.handleDiscover(span, era, req)
 	case methodToolsList:
 		return resultResponse(span, era, req.ID, &listToolsResult{Tools: s.registry.Tools()})
 	case methodToolsCall:
@@ -227,6 +230,24 @@ func protocolVersionLabel(version string) string {
 		return version
 	}
 	return "unsupported"
+}
+
+// handleDiscover answers the modern replacement for the initialize handshake.
+// The envelope around the payload is the era's to stamp (see
+// [modernEra.encodeResult]).
+func (s *extProcServer) handleDiscover(span trace.Span, era protocolEra, req *jsonrpc.Request) *mcpProcResponse {
+	return resultResponse(span, era, req.ID, &mcp.DiscoverResult{
+		SupportedVersions: supportedProtocolVersions,
+		Capabilities:      serverCapabilities(),
+		Instructions:      s.serverInfo.Instructions,
+	})
+}
+
+// serverCapabilities advertises tools only, since an OpenAPI document has
+// nothing to project onto resources or prompts. Both discovery answers use it,
+// and each gets a fresh value because the caller owns it.
+func serverCapabilities() *mcp.ServerCapabilities {
+	return &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}}
 }
 
 // mcpMethodLabel returns the method itself for any method some era serves and
@@ -252,9 +273,7 @@ func (s *extProcServer) handleInitialize(span trace.Span, era protocolEra, req *
 			Name:    s.serverInfo.Name,
 			Version: s.serverInfo.Version,
 		},
-		Capabilities: &mcp.ServerCapabilities{
-			Tools: &mcp.ToolCapabilities{},
-		},
+		Capabilities: serverCapabilities(),
 		Instructions: s.serverInfo.Instructions,
 	})
 }

--- a/mcp_handler_discover_test.go
+++ b/mcp_handler_discover_test.go
@@ -1,0 +1,55 @@
+package envoy_mcp_openapi_processor
+
+import (
+	"context"
+	"testing"
+
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerDiscover(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, "testdata/petstore.openapi.yaml")
+	server.serverInfo = ServerInfo{Name: "test-server", Version: "1.2.3", Instructions: "test instructions"}
+
+	requestBody := []byte(`{"jsonrpc":"2.0","id":7,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`)
+	headers := mcpRequestHeaders{protocolVersion: v20260728, method: methodDiscover}
+
+	response := server.mcpRequestHandler(context.Background(), requestBody, headers)
+	require.NotNil(t, response)
+	immediate := requireImmediateResponse(t, response.Immediate)
+	assert.Equal(t, typev3.StatusCode_OK, immediate.GetStatus().GetCode())
+
+	envelope, result := decodeJSONRPCResult(t, immediate.GetBody())
+	assert.Equal(t, float64(7), envelope["id"], "jsonrpc id")
+
+	assert.Equal(t, "complete", result["resultType"], "resultType")
+	assert.Equal(t, []any{"2026-07-28", "2025-11-25", "2025-06-18"}, result["supportedVersions"], "supportedVersions newest first")
+
+	capabilities, ok := result["capabilities"].(map[string]any)
+	require.True(t, ok, "result should contain 'capabilities'")
+	_, hasTools := capabilities["tools"]
+	assert.True(t, hasTools, "capabilities should advertise tools")
+
+	assert.Equal(t, "test instructions", result["instructions"], "instructions")
+	assert.Equal(t, float64(cacheTTLMillis), result["ttlMs"], "ttlMs")
+	assert.Equal(t, cacheScope, result["cacheScope"], "cacheScope")
+	assertServerInfoMeta(t, result, "test-server", "1.2.3")
+}
+
+func TestServerDiscoverIsModernOnly(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, "testdata/petstore.openapi.yaml")
+	requestBody := []byte(`{"jsonrpc":"2.0","id":7,"method":"server/discover","params":{}}`)
+
+	response := server.mcpRequestHandler(context.Background(), requestBody, mcpRequestHeaders{})
+	immediate := requireImmediateResponse(t, response.Immediate)
+
+	assert.Equal(t, typev3.StatusCode_OK, immediate.GetStatus().GetCode())
+	assertJSONRPCErrorBody(t, immediate.GetBody(), jsonrpc.CodeMethodNotFound)
+}

--- a/mcp_handler_fuzz_test.go
+++ b/mcp_handler_fuzz_test.go
@@ -33,6 +33,7 @@ func FuzzMcpRequestHandler(f *testing.F) {
 	f.Add([]byte(`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"nonExistentTool","arguments":{}}}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","id":9,"method":"unknown/method","params":{}}`))
 	// Modern (2026-07-28) requests carrying the protocol version in _meta
+	f.Add([]byte(`{"jsonrpc":"2.0","id":10,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","id":11,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"getPetById","arguments":{"petId":"42"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","id":13,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2099-01-01"}}}`))

--- a/mcp_handler_modern_test.go
+++ b/mcp_handler_modern_test.go
@@ -30,8 +30,8 @@ func TestModernRequests_HappyPaths(t *testing.T) {
 
 		_, result := decodeJSONRPCResult(t, immediate.GetBody())
 		assert.Equal(t, "complete", result["resultType"], "resultType")
-		assert.Equal(t, float64(listCacheTTLMillis), result["ttlMs"], "ttlMs")
-		assert.Equal(t, listCacheScope, result["cacheScope"], "cacheScope")
+		assert.Equal(t, float64(cacheTTLMillis), result["ttlMs"], "ttlMs")
+		assert.Equal(t, cacheScope, result["cacheScope"], "cacheScope")
 		assertServerInfoMeta(t, result, "test-server", "1.2.3")
 
 		tools, ok := result["tools"].([]any)

--- a/mcp_handler_tracing_test.go
+++ b/mcp_handler_tracing_test.go
@@ -48,6 +48,16 @@ func TestMcpRequestHandler_Tracing(t *testing.T) {
 			wantStatusCode: codes.Unset,
 			wantErrorEvent: false,
 		},
+		{
+			name:           "server/discover",
+			requestBody:    `{"jsonrpc":"2.0","id":4,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`,
+			headers:        mcpRequestHeaders{protocolVersion: v20260728, method: methodDiscover},
+			wantNilResp:    false,
+			wantMethod:     "server/discover",
+			wantMCPMethod:  "server/discover",
+			wantStatusCode: codes.Unset,
+			wantErrorEvent: false,
+		},
 		// json-rpc errors
 		{
 			name:                  "parse error invalid json",

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -102,9 +102,9 @@ func TestProtocolEraMethodSurface(t *testing.T) {
 	}{
 		{method: methodToolsList, legacyServes: true, modernServes: true},
 		{method: methodToolsCall, legacyServes: true, modernServes: true},
-		// The handshake exists only in the legacy era.
 		{method: methodInitialize, legacyServes: true, modernServes: false},
 		{method: methodNotificationsInitialized, legacyServes: true, modernServes: false},
+		{method: methodDiscover, legacyServes: false, modernServes: true},
 		{method: "resources/list", legacyServes: false, modernServes: false},
 	}
 
@@ -158,27 +158,35 @@ func TestProtocolEraEncodeResult(t *testing.T) {
 		name      string
 		newResult func() any
 		cacheable bool
+		// server/discover has no legacy result to check, since it replaces
+		// initialize.
+		legacyServes bool
 	}{
-		{name: "tools/call", newResult: func() any {
+		{name: "tools/call", legacyServes: true, newResult: func() any {
 			return &callToolResult{Content: newTextContent("hi")}
 		}},
-		{name: "tools/list", cacheable: true, newResult: func() any {
+		{name: "tools/list", legacyServes: true, cacheable: true, newResult: func() any {
 			return &listToolsResult{Tools: []*mcp.Tool{{Name: "tool"}}}
+		}},
+		{name: "server/discover", cacheable: true, newResult: func() any {
+			return &mcp.DiscoverResult{SupportedVersions: supportedProtocolVersions}
 		}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			legacyJSON, err := legacyEra{}.encodeResult(tt.newResult())
-			require.NoError(t, err)
-			var legacyObj map[string]any
-			require.NoError(t, json.Unmarshal(legacyJSON, &legacyObj))
-			assert.NotContains(t, legacyObj, "resultType")
-			assert.NotContains(t, legacyObj, "_meta")
-			// The hints postdate this era, and a zero ttlMs would mean
-			// "immediately stale" rather than "no hint given".
-			assert.NotContains(t, legacyObj, "ttlMs")
-			assert.NotContains(t, legacyObj, "cacheScope")
+			if tt.legacyServes {
+				legacyJSON, err := legacyEra{}.encodeResult(tt.newResult())
+				require.NoError(t, err)
+				var legacyObj map[string]any
+				require.NoError(t, json.Unmarshal(legacyJSON, &legacyObj))
+				assert.NotContains(t, legacyObj, "resultType")
+				assert.NotContains(t, legacyObj, "_meta")
+				// The hints postdate this era, and a zero ttlMs would mean
+				// "immediately stale" rather than "no hint given".
+				assert.NotContains(t, legacyObj, "ttlMs")
+				assert.NotContains(t, legacyObj, "cacheScope")
+			}
 
 			era := modernEra{serverInfo: ServerInfo{Name: "srv", Version: "1.2.3"}}
 			modernJSON, err := era.encodeResult(tt.newResult())
@@ -189,8 +197,8 @@ func TestProtocolEraEncodeResult(t *testing.T) {
 			assertServerInfoMeta(t, modernObj, "srv", "1.2.3")
 
 			if tt.cacheable {
-				assert.Equal(t, float64(listCacheTTLMillis), modernObj["ttlMs"])
-				assert.Equal(t, listCacheScope, modernObj["cacheScope"])
+				assert.Equal(t, float64(cacheTTLMillis), modernObj["ttlMs"])
+				assert.Equal(t, cacheScope, modernObj["cacheScope"])
 			} else {
 				assert.NotContains(t, modernObj, "ttlMs")
 				assert.NotContains(t, modernObj, "cacheScope")
@@ -231,6 +239,7 @@ func TestModernEraEncodeResultRefusesUnstampable(t *testing.T) {
 		{name: "untyped nil", result: nil},
 		{name: "nil tools/call result", result: (*callToolResult)(nil)},
 		{name: "nil tools/list result", result: (*listToolsResult)(nil)},
+		{name: "nil server/discover result", result: (*mcp.DiscoverResult)(nil)},
 		// initialize is legacy-only, so its result never reaches this era.
 		{name: "result of a method the era does not serve", result: &mcp.InitializeResult{}},
 	}
@@ -280,8 +289,8 @@ func TestListToolsResultDecodesAsSDKResult(t *testing.T) {
 
 	require.Len(t, decoded.Tools, 1)
 	assert.Equal(t, "tool", decoded.Tools[0].Name)
-	assert.Equal(t, listCacheTTLMillis, decoded.GetTTLMs())
-	assert.Equal(t, listCacheScope, decoded.GetCacheScope())
+	assert.Equal(t, cacheTTLMillis, decoded.GetTTLMs())
+	assert.Equal(t, cacheScope, decoded.GetCacheScope())
 	assertServerInfoMeta(t, map[string]any{"_meta": map[string]any(decoded.GetMeta())}, "srv", "1.2.3")
 }
 


### PR DESCRIPTION
With the initialize handshake gone, clients have no way to ask what a
server supports before talking to it. SEP-2575 fills that gap with
server/discover, which servers MUST implement: it advertises the
supported protocol versions, capabilities and identity, and clients MAY
call it up front to pick a version (changelog Major 3).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>