### PR TITLE
Upgrade the MCP Inspector to 2.x

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -115,18 +115,6 @@ case_delete_rejected() {
   pass "$name"
 }
 
-# CORS preflight is needed for local browser-based testing (MCP inspector)
-# and Envoy is configured to skip ext_proc in this case.
-case_cors_preflight() {
-  local name="OPTIONS /mcp CORS preflight passes through"
-  request "$name" 200 -X OPTIONS \
-    -H 'Origin: http://localhost:6274' \
-    -H 'Access-Control-Request-Method: POST' || return 0
-  assert_header "$name" 'access-control-allow-origin' || return 0
-  assert_header "$name" 'access-control-allow-methods' || return 0
-  pass "$name"
-}
-
 # tools/list is answered by the processor itself (immediate-response path).
 case_tools_list() {
   local name="tools/list -> non-empty tool list"
@@ -394,7 +382,6 @@ echo "=== running probes ==="
 case_bodyless_request
 case_get_rejected
 case_delete_rejected
-case_cors_preflight
 case_tools_list
 case_notification
 case_empty_upstream_body

--- a/examples/mcp-server/README.md
+++ b/examples/mcp-server/README.md
@@ -36,13 +36,12 @@ back into an MCP result.
 
 2. To access the MCP Inspector UI:
 
-    - Go to http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:10000/mcp
-    - Select **Connection Type: Direct**
-    - Click **Connect**
+    - Go to http://localhost:6274
+    - Select the preconfigured **petstore-mcp-{modern,legacy}** server and toggle **Connect**
 
 3. Once connected, you can:
 
-    - **List Tools:** see the MCP tools generated from the Petstore OpenAPI spec.
+    - **List Tools:** select "Tools" tab to see the MCP tools generated from the Petstore OpenAPI spec.
     - **Call Tools:** invoke individual tools and inspect the responses.
 
 4. To stop the example, press `Ctrl+C` in the terminal where docker compose was running.
@@ -54,4 +53,5 @@ back into an MCP result.
 | `main.go`            | Entrypoint that runs the external processor (ext_proc) server.                                       |
 | `envoy-mcp.yaml`     | Envoy configuration wiring the ext_proc filter and the Prism upstream.                               |
 | `docker-compose.yml` | Compose file defining the `envoy-mcp-openapi-processor`, `envoy`, `prism`, and `inspector` services. |
+| `mcp-catalog.json`   | Server catalog preloaded into the Inspector so the Petstore MCP server is ready to connect.          |
 | `Dockerfile`         | Multi-stage build: compiles the Go ext_proc binary into a minimal image.                             |

--- a/examples/mcp-server/docker-compose.yml
+++ b/examples/mcp-server/docker-compose.yml
@@ -34,18 +34,14 @@ services:
     volumes:
       - "../../testdata/petstore.openapi.yaml:/openapi/petstore.openapi.yaml:ro"
   inspector:
-    image: ghcr.io/modelcontextprotocol/inspector:0.21.2-hotfix-3
+    image: ghcr.io/modelcontextprotocol/inspector:2.2.0
+    command: ["--web", "--config", "/home/node/mcp-catalog.json"]
     ports:
       - "127.0.0.1:6274:6274"
     environment:
-      HOST: "0.0.0.0"
-      MCP_AUTO_OPEN_ENABLED: "false"
-    healthcheck:
-      test: "node -e \"require('http').get('http://127.0.0.1:6274', (res) => process.exit(res.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))\""
-      interval: 1s
-      timeout: 1s
-      retries: 5
-      start_period: 1s
+      DANGEROUSLY_OMIT_AUTH: "true"
+    volumes:
+      - "./mcp-catalog.json:/home/node/mcp-catalog.json:ro"
 
 volumes:
   shared-uds:

--- a/examples/mcp-server/envoy-mcp.yaml
+++ b/examples/mcp-server/envoy-mcp.yaml
@@ -17,37 +17,13 @@ static_resources:
                   virtual_hosts:
                     - name: local_service
                       domains: ["*"]
-                      typed_per_filter_config:
-                        envoy.filters.http.cors:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
-                          allow_origin_string_match:
-                            - prefix: "http://localhost"
-                          allow_methods: "OPTIONS, GET, POST, PATCH, PUT, DELETE"
-                          allow_headers: "*"
-                          max_age: "86400"
                       routes:
-                        - name: mcp_inspector_cors_preflight
-                          match:
-                            prefix: "/mcp"
-                            headers:
-                              - name: ":method"
-                                string_match:
-                                  exact: "OPTIONS"
-                          route:
-                            cluster: prism
-                          typed_per_filter_config:
-                            envoy.filters.http.ext_proc:
-                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
-                              disabled: true
                         - name: main
                           match:
                             prefix: "/mcp"
                           route:
                             cluster: prism
                 http_filters:
-                  - name: envoy.filters.http.cors
-                    typed_config:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor

--- a/examples/mcp-server/main.go
+++ b/examples/mcp-server/main.go
@@ -25,6 +25,9 @@ func main() {
 			OpenAPISpecPattern: "/home/app/conf/openapi/*.yaml",
 			StructuredOutput:   true,
 		},
+		// The MCP Inspector connects from its own container, so requests carry
+		// the Docker service name as Host instead of a loopback address.
+		AllowedHosts: []string{"localhost", "127.0.0.1", "::1", "envoy"},
 		ServerInfo: mcp_proc.ServerInfo{
 			Name:         "mcp-server",
 			Version:      "1.0.0",

--- a/examples/mcp-server/mcp-catalog.json
+++ b/examples/mcp-server/mcp-catalog.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "petstore-mcp-modern": {
+      "type": "streamable-http",
+      "url": "http://envoy:10000/mcp",
+      "protocolEra": "modern",
+      "headers": {
+        "Authorization": "Bearer test",
+        "api_key": "test"
+      }
+    },
+    "petstore-mcp-legacy": {
+      "type": "streamable-http",
+      "url": "http://envoy:10000/mcp",
+      "protocolEra": "legacy",
+      "headers": {
+        "Authorization": "Bearer test",
+        "api_key": "test"
+      }
+    }
+  }
+}


### PR DESCRIPTION
2.x connects from its own backend instead of the browser, so the "Direct" mode the example used is gone. Servers now come from a read-only catalog file, which registers the endpoint twice, once per protocol era, so legacy and modern are each a click away. Requests reach Envoy with "envoy" as Host (hence the AllowedHosts entry), and Envoy's browser-only CORS setup drops out along with its e2e probe.